### PR TITLE
Add Xcode13Beta support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,18 @@
 
 import PackageDescription
 
+#if swift(<5.5)
+let swiftSyntax: Package.Dependency = .package(
+    name: "SwiftSyntax",
+    url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0")
+)
+#else
+let swiftSyntax: Package.Dependency = .package(
+    name: "SwiftSyntax",
+    url: "https://github.com/apple/swift-syntax.git", .revision("swift-DEVELOPMENT-SNAPSHOT-2021-05-14-a")
+)
+#endif
+
 let package = Package(
     name: "SwiftTypeReader",
     products: [
@@ -11,10 +23,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(
-            name: "SwiftSyntax",
-            url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0")
-        )
+        swiftSyntax,
     ],
     targets: [
         .target(


### PR DESCRIPTION
Xcode13Beta has lib_InternalSwiftSyntaxParser that's node_hash value is `4f85168b3860f575ce60ac0d223fc89da37014df`. select suitable commit of SwiftSyntax.