### PR TITLE
use BinarySwiftSyntax

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/omochi/BinarySwiftSyntax",
         "state": {
           "branch": "main",
-          "revision": "21cfc03f3f518a69bf49767c09eaa475ad523d1a",
+          "revision": "09f048537e6ad197f68fa9eab5070c59ccc64851",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,8 +2,17 @@
   "object": {
     "pins": [
       {
+        "package": "BinarySwiftSyntax",
+        "repositoryURL": "https://github.com/omochi/BinarySwiftSyntax",
+        "state": {
+          "branch": "main",
+          "revision": "21cfc03f3f518a69bf49767c09eaa475ad523d1a",
+          "version": null
+        }
+      },
+      {
         "package": "SwiftSyntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax.git",
+        "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
           "branch": null,
           "revision": "2fff9fc25cdc059379b6bd309377cfab45d8520c",

--- a/Package.swift
+++ b/Package.swift
@@ -2,18 +2,6 @@
 
 import PackageDescription
 
-#if swift(<5.5)
-let swiftSyntax: Package.Dependency = .package(
-    name: "SwiftSyntax",
-    url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0")
-)
-#else
-let swiftSyntax: Package.Dependency = .package(
-    name: "SwiftSyntax",
-    url: "https://github.com/apple/swift-syntax.git", .revision("swift-DEVELOPMENT-SNAPSHOT-2021-05-14-a")
-)
-#endif
-
 let package = Package(
     name: "SwiftTypeReader",
     products: [
@@ -23,13 +11,29 @@ let package = Package(
         )
     ],
     dependencies: [
-        swiftSyntax,
+        .package(
+            name: "SwiftSyntax",
+            url: "https://github.com/apple/swift-syntax", .exact("0.50400.0")
+        ),
+        .package(
+            name: "BinarySwiftSyntax",
+            url: "https://github.com/omochi/BinarySwiftSyntax", .branch("main")
+        )
     ],
     targets: [
         .target(
             name: "SwiftTypeReader",
             dependencies: [
-                "SwiftSyntax"
+                .product(
+                    name: "SwiftSyntax",
+                    package: "SwiftSyntax",
+                    condition: .when(platforms: [.linux])
+                ),
+                .product(
+                    name: "SwiftSyntax-Xcode12.5",
+                    package: "BinarySwiftSyntax",
+                    condition: .when(platforms: [.macOS])
+                )
             ]
         ),
         .testTarget(


### PR DESCRIPTION
BinarySwiftSyntaxを使うことでSwiftSyntaxをコンパイルするときの環境に依存しなくなりました。

`libInternalSwiftSyntaxParser.dylib` の実行時指定だけすればXcode13でも動くはず