### PR TITLE
Search other module's type information

### DIFF
--- a/Sources/SwiftTypeReader/Component/TypeResolver.swift
+++ b/Sources/SwiftTypeReader/Component/TypeResolver.swift
@@ -33,13 +33,12 @@ struct TypeResolver {
             return t
         }
 
-        if let swiftModule = module.modules?.swift,
-           let t = try findTypeInModule(
-            module: swiftModule,
-            name: name,
-            location: swiftModule.asLocation()
-           ) {
-            return t
+        for module in (module.modules?.modules ?? []) {
+            if let t = try findTypeInModule(
+                module: module, name: name, location: module.asLocation()
+            ) {
+                return t 
+            }
         }
 
         return nil

--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -7,12 +7,13 @@ public final class Reader {
         public var module: Module
     }
 
-    public init(modules: Modules? = nil) {
+    public init(modules: Modules? = nil, moduleName: String = "main") {
         self.modules = modules ?? Modules()
+        self.moduleName = moduleName
     }
 
     public var modules: Modules
-    public var moduleName: String = "main"
+    public var moduleName: String
 
     public func read(file: URL, module: Module? = nil) throws -> Result {
         let module = initModule(module)

--- a/Tests/SwiftTypeReaderTests/SwiftTypeReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/SwiftTypeReaderTests.swift
@@ -280,7 +280,7 @@ struct S {
     func testModules() throws {
         let modules = Modules()
         _ = try Reader(modules: modules, moduleName: "MyLib").read(source: """
-enum E {
+public enum E {
     case a
 }
 """

--- a/Tests/SwiftTypeReaderTests/SwiftTypeReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/SwiftTypeReaderTests.swift
@@ -276,4 +276,31 @@ struct S {
         XCTAssertEqual(y.name, "y")
         XCTAssertEqual(try y.type().description, "A.B.C")
     }
+
+    func testModules() throws {
+        let modules = Modules()
+        _ = try Reader(modules: modules, moduleName: "MyLib").read(source: """
+enum E {
+    case a
+}
+"""
+        )
+
+        let result = try Reader(modules: modules, moduleName: "main").read(source: """
+import MyLib
+
+protocol P {
+    func f() -> E
+}
+"""
+        )
+
+        let p = try XCTUnwrap(result.module.types[safe: 0]?.protocol)
+        XCTAssertEqual(p.name, "P")
+        let f = try XCTUnwrap(p.functionRequirements[safe: 0])
+        XCTAssertEqual(f.name, "f")
+        let e = try XCTUnwrap(try f.outputType()?.enum)
+        let c = try XCTUnwrap(e.caseElements[safe: 0])
+        XCTAssertEqual(c.name, "a")
+    }
 }


### PR DESCRIPTION
 ## 課題
 
 `TypeResolver` が型を探索する際、すでに読み込み済みの他モジュールの型情報を探索してくれない問題を修正します。
 具体的には、下記のようなモジュール構成の場合に、`main.P.f` の返り値である `E` の型情報が読み取れなくなっています。
 `E` の型名だけは取り出せるのでこれまでは課題が顕現しませんでしたが、 `E` がenumかどうか、の検証を始めると課題が浮かび上がりました。
 
 ```swift
// MyLib モジュール
public enum E {
    case a
}

// main モジュール
import MyLib

protocol P {
    func f() -> E
}
```
 
 ## 解決方法
 
 現状では `Swift` モジュールだけハードコードで探索されている部分を自身の親 `Modules` 全体を読み込むように変更します。
 
 ## その他
 
 課題はこれで解決しますが、依然厳密さは足りていない状況で、ファイル単位での `import` declの有無を検証しないため、本来import文が不足していて読み取れないはずの型を読み取れてしまうことがあります。
 現状のSwiftTypeReaderではファイル単位で型定義のスコープを管理する仕組みがないので、これは一旦諦めて `Modules` に読み込まれたモジュールは全てimportされているという前提ということにしています。