### PR TITLE
Use original SwiftSyntax

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "SwiftSyntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax",
-        "state": {
-          "branch": null,
-          "revision": "75e60475d9d8fd5bbc16a12e0eaa2cb01b0c322e",
-          "version": "0.50500.0"
-        }
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax",
+      "state" : {
+        "branch" : "0.50600.1",
+        "revision" : "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,37 +1,6 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 
 import PackageDescription
-
-var dependencies: [Package.Dependency] = []
-var targetDependencies: [Target.Dependency] = []
-
-#if os(macOS)
-dependencies.append(
-    .package(
-        name: "BinarySwiftSyntax",
-        url: "https://github.com/omochi/BinarySwiftSyntax", .branch("main")
-    )
-)
-targetDependencies.append(
-    .product(
-        name: "SwiftSyntax-Xcode13.0",
-        package: "BinarySwiftSyntax"
-    )
-)
-#else
-dependencies.append(
-    .package(
-        name: "SwiftSyntax",
-        url: "https://github.com/apple/swift-syntax", .exact("0.50500.0")
-    )
-)
-targetDependencies.append(
-    .product(
-        name: "SwiftSyntax",
-        package: "SwiftSyntax"
-    )
-)
-#endif
 
 let package = Package(
     name: "SwiftTypeReader",
@@ -41,11 +10,15 @@ let package = Package(
             targets: ["SwiftTypeReader"]
         )
     ],
-    dependencies: dependencies,
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-syntax", branch: "0.50600.1"),
+    ],
     targets: [
         .target(
             name: "SwiftTypeReader",
-            dependencies: targetDependencies
+            dependencies: [
+                .product(name: "SwiftSyntaxParser", package: "swift-syntax"),
+            ]
         ),
         .testTarget(
             name: "SwiftTypeReaderTests",

--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftSyntax
+import SwiftSyntaxParser
 
 public final class Reader {
     public struct Result {


### PR DESCRIPTION
## Issue

Xcode 14.0 beta (14A5228q) 及びSwift 5.7でBinarySwiftSyntaxが利用できなくなった。（ https://github.com/omochi/BinarySwiftSyntax/issues/5 ）
その影響でこのパッケージもビルドできなくなっている。

 
 ## Fix

本家のSwiftSyntaxを使う。

本家のSwiftSyntaxは最新のリリースから `_InternalSwiftSyntaxParser.dylib` を同梱するようになり、実行環境のXcodeに依存しなくても良くなった。

https://github.com/apple/swift-syntax/releases/tag/0.50600.1
