### PR TITLE
Locationが常にmoduleを持つ

### DIFF
--- a/Sources/SwiftTypeReader/Component/LocationResolver.swift
+++ b/Sources/SwiftTypeReader/Component/LocationResolver.swift
@@ -12,17 +12,11 @@ struct LocationResolver {
     }
 
     private func resolve(modules: [Module], location: Location) throws -> Element? {
-        guard let first = location.elements.first,
-              case .module(let name) = first else
-        {
-            throw MessageError("broken location: \(location)")
-        }
-
-        guard let module = modules.first(where: { $0.name == name }) else {
+        guard let module = modules.first(where: { $0.name == location.module }) else {
             return nil
         }
 
-        return try resolve(module: module, location: location, index: 1)
+        return try resolve(module: module, location: location, index: 0)
     }
 
     private func resolve(element: Element, location: Location, index: Int) throws -> Element? {
@@ -74,8 +68,6 @@ struct LocationResolver {
                 location: location,
                 index: index + 1
             )
-        case .module:
-            throw MessageError("broken location: \(location)")
         }
     }
 
@@ -88,7 +80,7 @@ struct LocationResolver {
         case .type:
             // TODO: type name dot expression
             return nil
-        case .genericParameter, .module:
+        case .genericParameter:
             throw MessageError("broken location: \(location)")
         }
     }

--- a/Sources/SwiftTypeReader/Component/TypeResolver.swift
+++ b/Sources/SwiftTypeReader/Component/TypeResolver.swift
@@ -67,16 +67,14 @@ struct TypeResolver {
     }
 
     private func location(module: Module, specifier: TypeSpecifier) -> Location {
-        var elements: [LocationElement] = [
-            .module(name: module.name)
-        ]
+        var elements: [LocationElement] = []
 
         for spec in specifier.elements {
             // FIXME: generic arguments
             elements.append(.type(name: spec.name))
         }
 
-        return Location(elements)
+        return Location(module: module.name, elements: elements)
     }
 
     private func findFirstElementType(specifier: TypeSpecifier) throws -> SType? {
@@ -88,15 +86,15 @@ struct TypeResolver {
             var location = specifier.location
 
             while true {
-                if location.elements.isEmpty {
-                    break
-                }
-
                 if let type = try getType(name: first.name, location: location) {
                     return type
                 }
 
-                location = location.deletingLast()
+                if location.elements.isEmpty {
+                    break
+                }
+
+                location.removeLast()
             }
 
             /*

--- a/Sources/SwiftTypeReader/Entity/Location.swift
+++ b/Sources/SwiftTypeReader/Entity/Location.swift
@@ -1,47 +1,52 @@
-/*
- First element must be module
-
- FIXME: extract first element to single property
- */
 public struct Location: Hashable & CustomStringConvertible {
-    public init(_ elements: [LocationElement]) {
+    public init(
+        module: String,
+        elements: [LocationElement] = []
+    ) {
+        self.module = module
         self.elements = elements
     }
 
+    public var module: String
     public var elements: [LocationElement]
 
     public var description: String {
-        elements.map { $0.description }.joined(separator: " -> ")
+        var parts: [String] = ["module(\(module))"]
+        parts += elements.map { $0.description }
+        return parts.joined(separator: " -> ")
+    }
+
+    public mutating func append(_ element: LocationElement) {
+        elements.append(element)
     }
 
     public func appending(_ element: LocationElement) -> Location {
-        var elements = elements
-        elements.append(element)
-        return Location(elements)
+        var copy = self
+        copy.append(element)
+        return copy
     }
 
-    public func deletingLast() -> Location {
-        if elements.isEmpty { return self }
-
-        var elements = elements
+    public mutating func removeLast() {
         elements.removeLast()
-        return Location(elements)
+    }
+
+    public func removingLast() -> Location {
+        var copy = self
+        copy.removeLast()
+        return copy
     }
 }
 
 public enum LocationElement: Hashable & CustomStringConvertible {
-    case module(name: String)
     case type(name: String)
     case genericParameter(index: Int)
 
     public var description: String {
         switch self {
-        case .module(name: let name):
-            return "module(name: \(name))"
         case .type(name: let name):
-            return "type(name: \(name))"
+            return "type(\(name))"
         case .genericParameter(index: let index):
-            return "genericParameter(index: \(index))"
+            return "genericParameter(\(index))"
         }
     }
 }

--- a/Sources/SwiftTypeReader/Entity/Module.swift
+++ b/Sources/SwiftTypeReader/Entity/Module.swift
@@ -14,7 +14,7 @@ public final class Module {
     public var types: [SType] = []
 
     public func asLocation() -> Location {
-        Location([.module(name: name)])
+        Location(module: name)
     }
 
     public var modulesForFind: [Module] {
@@ -50,8 +50,6 @@ public final class Module {
 
     public func get(element: LocationElement) -> Element? {
         switch element {
-        case .module(name: let name):
-            return getModule(name: name).map { .module($0) }
         case .type(name: let name):
             return getType(name: name).map { .type($0) }
         case .genericParameter:

--- a/Sources/SwiftTypeReader/Type/RegularType.swift
+++ b/Sources/SwiftTypeReader/Type/RegularType.swift
@@ -106,12 +106,12 @@ extension RegularTypeProtocol {
     }
 
     public func asSpecifier() -> TypeSpecifier {
-        var elements: [TypeSpecifier.Element] = []
+        var elements: [TypeSpecifier.Element] = [
+            .init(name: location.module)
+        ]
 
         for element in location.elements {
             switch element {
-            case .module(name: let name):
-                elements.append(.init(name: name))
             case .type(name: let name):
                 elements.append(.init(name: name))
             case .genericParameter:

--- a/Tests/SwiftTypeReaderTests/LocationResolveTests.swift
+++ b/Tests/SwiftTypeReaderTests/LocationResolveTests.swift
@@ -17,28 +17,28 @@ struct A {
 
         XCTAssertEqual(
             try context.resolve(
-                location: Location([.module(name: "Swift")])
+                location: Location(module: "Swift")
             )?.module?.name,
             "Swift"
         )
 
         XCTAssertEqual(
             try context.resolve(
-                location: Location([.module(name: "Swift"), .type(name: "Int")])
+                location: Location(module: "Swift", elements: [.type(name: "Int")])
             )?.type?.asSpecifier().elements,
             [.init(name: "Swift"), .init(name: "Int")]
         )
 
         XCTAssertEqual(
             try context.resolve(
-                location: Location([.module(name: "main")])
+                location: Location(module: "main")
             )?.module?.name,
             "main"
         )
 
         XCTAssertEqual(
             try context.resolve(
-                location: Location([.module(name: "main"), .type(name: "G")])
+                location: Location(module: "main", elements: [.type(name: "G")])
             )?.type?.asSpecifier().elements,
             [.init(name: "main"), .init(name: "G")]
         )
@@ -46,13 +46,13 @@ struct A {
         do {
             let t = try XCTUnwrap(
                 try context.resolve(
-                    location: Location([.module(name: "main"), .type(name: "G"), .genericParameter(index: 0)])
+                    location: Location(module: "main", elements: [.type(name: "G"), .genericParameter(index: 0)])
                 )?.type
             )
 
             XCTAssertEqual(
                 try t.location(),
-                Location([.module(name: "main"), .type(name: "G")])
+                Location(module: "main", elements: [.type(name: "G")])
             )
             XCTAssertEqual(
                 t.asSpecifier().elements,
@@ -62,21 +62,21 @@ struct A {
 
         XCTAssertEqual(
             try context.resolve(
-                location: Location([.module(name: "main"), .type(name: "A"), .type(name: "B")])
+                location: Location(module: "main", elements: [.type(name: "A"), .type(name: "B")])
             )?.type?.asSpecifier().elements,
             [.init(name: "main"), .init(name: "A"), .init(name: "B")]
         )
 
         XCTAssertEqual(
             try context.resolve(
-                location: Location([.module(name: "main"), .type(name: "A"), .type(name: "B"), .type(name: "C")])
+                location: Location(module: "main", elements: [.type(name: "A"), .type(name: "B"), .type(name: "C")])
             )?.type?.asSpecifier().elements,
             [.init(name: "main"), .init(name: "A"), .init(name: "B"), .init(name: "C")]
         )
 
         XCTAssertEqual(
             try context.resolve(
-                location: Location([.module(name: "main"), .type(name: "A"), .type(name: "G")])
+                location: Location(module: "main", elements: [.type(name: "A"), .type(name: "G")])
             )?.type?.asSpecifier().elements,
             [.init(name: "main"), .init(name: "A"), .init(name: "G")]
         )
@@ -84,13 +84,16 @@ struct A {
         do {
             let t = try XCTUnwrap(
                 try context.resolve(
-                    location: Location([.module(name: "main"), .type(name: "A"), .type(name: "G"), .genericParameter(index: 0)])
+                    location: Location(
+                        module: "main",
+                        elements: [.type(name: "A"), .type(name: "G"), .genericParameter(index: 0)]
+                    )
                 )?.type
             )
 
             XCTAssertEqual(
                 try t.location(),
-                Location([.module(name: "main"), .type(name: "A"), .type(name: "G")])
+                Location(module: "main", elements: [.type(name: "A"), .type(name: "G")])
             )
             XCTAssertEqual(
                 t.asSpecifier().elements,

--- a/Tests/SwiftTypeReaderTests/SwiftTypeReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/SwiftTypeReaderTests.swift
@@ -13,7 +13,7 @@ struct S {
         let s = try XCTUnwrap(module.types[safe: 0]?.struct)
         XCTAssertEqual(s.name, "S")
 
-        XCTAssertEqual(s.location, Location([.module(name: "main")]))
+        XCTAssertEqual(s.location, Location(module: "main"))
 
         XCTAssertEqual(s.storedProperties.count, 1)
         let a = try XCTUnwrap(s.storedProperties[safe: 0])
@@ -243,10 +243,7 @@ struct S<T> {
         let at = try XCTUnwrap(a.type().genericParameter)
         XCTAssertEqual(
             at.location,
-            Location([
-                .module(name: "main"),
-                .type(name: "S")
-            ])
+            Location(module: "main", elements: [.type(name: "S")])
         )
     }
 
@@ -290,7 +287,7 @@ struct A {
         XCTAssertEqual(b.name, "B")
         XCTAssertEqual(
             b.location,
-            Location([.module(name: "main"), .type(name: "A")])
+            Location(module: "main", elements: [.type(name: "A")])
         )
     }
 
@@ -309,7 +306,7 @@ enum A {
         XCTAssertEqual(b.name, "B")
         XCTAssertEqual(
             b.location,
-            Location([.module(name: "main"), .type(name: "A")])
+            Location(module: "main", elements: [.type(name: "A")])
         )
     }
 

--- a/Tests/SwiftTypeReaderTests/TypeResolveTests.swift
+++ b/Tests/SwiftTypeReaderTests/TypeResolveTests.swift
@@ -18,7 +18,7 @@ struct A {
         XCTAssertEqual(
             try TypeSpecifier(
                 module: module, file: nil,
-                location: Location([.module(name: "main")]),
+                location: Location(module: "main"),
                 elements: [.init(name: "A")]
             ).resolve().asSpecifier().elements,
             [.init(name: "main"), .init(name: "A")]
@@ -27,7 +27,7 @@ struct A {
         XCTAssertEqual(
             try TypeSpecifier(
                 module: module, file: nil,
-                location: Location([.module(name: "main")]),
+                location: Location(module: "main"),
                 elements: [.init(name: "A"), .init(name: "A")]
             ).resolve().asSpecifier().elements,
             [.init(name: "main"), .init(name: "A"), .init(name: "A")]
@@ -36,7 +36,7 @@ struct A {
         XCTAssertEqual(
             try TypeSpecifier(
                 module: module, file: nil,
-                location: Location([.module(name: "main")]),
+                location: Location(module: "main"),
                 elements: [.init(name: "A"), .init(name: "A"), .init(name: "A")]
             ).resolve().asSpecifier().elements,
             [.init(name: "main"), .init(name: "A"), .init(name: "A"), .init(name: "A")]
@@ -47,7 +47,7 @@ struct A {
         XCTAssertEqual(
             try TypeSpecifier(
                 module: module, file: nil,
-                location: Location([.module(name: "main"), .type(name: "A")]),
+                location: Location(module: "main", elements: [.type(name: "A")]),
                 elements: [.init(name: "A")]
             ).resolve().asSpecifier().elements,
             [.init(name: "main"), .init(name: "A"), .init(name: "A")]
@@ -56,7 +56,7 @@ struct A {
         XCTAssertEqual(
             try TypeSpecifier(
                 module: module, file: nil,
-                location: Location([.module(name: "main"), .type(name: "A")]),
+                location: Location(module: "main", elements: [.type(name: "A")]),
                 elements: [.init(name: "A"), .init(name: "A")]
             ).resolve().asSpecifier().elements,
             [.init(name: "main"), .init(name: "A"), .init(name: "A"), .init(name: "A")]
@@ -65,7 +65,7 @@ struct A {
         XCTAssertNotNil(
             try TypeSpecifier(
                 module: module, file: nil,
-                location: Location([.module(name: "main"), .type(name: "A")]),
+                location: Location(module: "main", elements: [.type(name: "A")]),
                 elements: [.init(name: "A"), .init(name: "A"), .init(name: "A")]
             ).resolve().unresolved
         )
@@ -75,7 +75,7 @@ struct A {
         XCTAssertEqual(
             try TypeSpecifier(
                 module: module, file: nil,
-                location: Location([.module(name: "main"), .type(name: "A"), .type(name: "A")]),
+                location: Location(module: "main", elements: [.type(name: "A"), .type(name: "A")]),
                 elements: [.init(name: "A")]
             ).resolve().asSpecifier().elements,
             [.init(name: "main"), .init(name: "A"), .init(name: "A"), .init(name: "A")]
@@ -84,7 +84,7 @@ struct A {
         XCTAssertNotNil(
             try TypeSpecifier(
                 module: module, file: nil,
-                location: Location([.module(name: "main"), .type(name: "A"), .type(name: "A")]),
+                location: Location(module: "main", elements: [.type(name: "A"), .type(name: "A")]),
                 elements: [.init(name: "A"), .init(name: "A")]
             ).resolve().unresolved
         )
@@ -94,7 +94,7 @@ struct A {
         XCTAssertEqual(
             try TypeSpecifier(
                 module: module, file: nil,
-                location: Location([.module(name: "main")]),
+                location: Location(module: "main"),
                 elements: [.init(name: "main"), .init(name: "A"), .init(name: "A")]
             ).resolve().asSpecifier().elements,
             [.init(name: "main"), .init(name: "A"), .init(name: "A")]
@@ -103,7 +103,7 @@ struct A {
         XCTAssertEqual(
             try TypeSpecifier(
                 module: module, file: nil,
-                location: Location([.module(name: "main"), .type(name: "A")]),
+                location: Location(module: "main", elements: [.type(name: "A")]),
                 elements: [.init(name: "main"), .init(name: "A"), .init(name: "A")]
             ).resolve().asSpecifier().elements,
             [.init(name: "main"), .init(name: "A"), .init(name: "A")]
@@ -112,7 +112,7 @@ struct A {
         XCTAssertEqual(
             try TypeSpecifier(
                 module: module, file: nil,
-                location: Location([.module(name: "main"), .type(name: "A"), .type(name: "A")]),
+                location: Location(module: "main", elements: [.type(name: "A"), .type(name: "A")]),
                 elements: [.init(name: "main"), .init(name: "A"), .init(name: "A")]
             ).resolve().asSpecifier().elements,
             [.init(name: "main"), .init(name: "A"), .init(name: "A")]
@@ -144,7 +144,7 @@ struct A {
         XCTAssertEqual(
             try TypeSpecifier(
                 module: moduleY, file: nil,
-                location: Location([.module(name: "Y")]),
+                location: Location(module: "Y"),
                 elements: [.init(name: "Int")]
             ).resolve().asSpecifier().elements,
             [.init(name: "Swift"), .init(name: "Int")]
@@ -153,7 +153,7 @@ struct A {
         XCTAssertEqual(
             try TypeSpecifier(
                 module: moduleX, file: nil,
-                location: Location([.module(name: "X")]),
+                location: Location(module: "X"),
                 elements: [.init(name: "Int")]
             ).resolve().asSpecifier().elements,
             [.init(name: "X"), .init(name: "Int")]
@@ -162,7 +162,7 @@ struct A {
         XCTAssertEqual(
             try TypeSpecifier(
                 module: moduleY, file: nil,
-                location: Location([.module(name: "Y"), .type(name: "A")]),
+                location: Location(module: "Y", elements: [.type(name: "A")]),
                 elements: [.init(name: "Int")]
             ).resolve().asSpecifier().elements,
             [.init(name: "Y"), .init(name: "A"), .init(name: "Int")]


### PR DESCRIPTION
Locationはdeclのパスを現す
全てのdeclはなんらかのモジュールに所属しているので、
これを型で現す

踏む事がないはずの動的なエラーが減らせる