### PR TITLE
型はLocationをunownedで持つ

### DIFF
--- a/Sources/SwiftTypeReader/Component/LocationResolver.swift
+++ b/Sources/SwiftTypeReader/Component/LocationResolver.swift
@@ -4,41 +4,41 @@
 struct LocationResolver {
     var context: Context
 
-    func resolve(module: Module?, location: Location) throws -> Element? {
-        return try resolve(
+    func resolve(module: Module?, location: Location) -> Element? {
+        return resolve(
             modules: module?.modulesForFind ?? context.modules,
             location: location
         )
     }
 
-    private func resolve(modules: [Module], location: Location) throws -> Element? {
+    private func resolve(modules: [Module], location: Location) -> Element? {
         guard let module = modules.first(where: { $0.name == location.module }) else {
             return nil
         }
 
-        return try resolve(module: module, location: location, index: 0)
+        return resolve(module: module, location: location, index: 0)
     }
 
-    private func resolve(element: Element, location: Location, index: Int) throws -> Element? {
+    private func resolve(element: Element, location: Location, index: Int) -> Element? {
         switch element {
         case .module(let module):
-            return try resolve(module: module, location: location, index: index)
+            return resolve(module: module, location: location, index: index)
         case .type(let type):
-            return try resolve(type: type, location: location, index: index)
+            return resolve(type: type, location: location, index: index)
         }
     }
 
-    private func resolve(module: Module, location: Location, index: Int) throws -> Element? {
+    private func resolve(module: Module, location: Location, index: Int) -> Element? {
         guard index < location.elements.count else {
             return .module(module)
         }
         guard let element = module.get(element: location.elements[index]) else {
             return nil
         }
-        return try resolve(element: element, location: location, index: index + 1)
+        return resolve(element: element, location: location, index: index + 1)
     }
 
-    private func resolve(type: SType, location: Location, index: Int) throws -> Element? {
+    private func resolve(type: SType, location: Location, index: Int) -> Element? {
         guard index < location.elements.count else {
             return .type(type)
         }
@@ -51,19 +51,19 @@ struct LocationResolver {
                 return nil
             }
 
-            return try resolve(
+            return resolve(
                 type: nestedType,
                 location: location,
                 index: index + 1
             )
         case .genericParameter(let gi):
-            guard let type = type.regular else { return nil }
-
-            guard gi < type.genericParameters.count else {
-                throw MessageError("broken location: \(location)")
+            guard let type = type.regular,
+                  gi < type.genericParameters.count else
+            {
+                return nil
             }
 
-            return try resolve(
+            return resolve(
                 genericParameter: type.genericParameters[gi],
                 location: location,
                 index: index + 1
@@ -71,7 +71,7 @@ struct LocationResolver {
         }
     }
 
-    private func resolve(genericParameter: GenericParameterType, location: Location, index: Int) throws -> Element? {
+    private func resolve(genericParameter: GenericParameterType, location: Location, index: Int) -> Element? {
         guard index < location.elements.count else {
             return .type(.genericParameter(genericParameter))
         }
@@ -81,7 +81,7 @@ struct LocationResolver {
             // TODO: type name dot expression
             return nil
         case .genericParameter:
-            throw MessageError("broken location: \(location)")
+            return nil
         }
     }
 }

--- a/Sources/SwiftTypeReader/Entity/AssociatedValue.swift
+++ b/Sources/SwiftTypeReader/Entity/AssociatedValue.swift
@@ -9,8 +9,8 @@ public struct AssociatedValue {
 
     public var name: String?
     
-    public func type() throws -> SType {
-        try unresolvedType.resolved()
+    public func type() -> SType {
+        unresolvedType.resolved()
     }
 
     public var unresolvedType: SType

--- a/Sources/SwiftTypeReader/Entity/Context.swift
+++ b/Sources/SwiftTypeReader/Entity/Context.swift
@@ -23,8 +23,8 @@ public final class Context {
         return module
     }
 
-    public func resolve(location: Location) throws -> Element? {
-        return try LocationResolver(context: self)
+    public func resolve(location: Location) -> Element? {
+        return LocationResolver(context: self)
             .resolve(module: nil, location: location)
     }
 

--- a/Sources/SwiftTypeReader/Entity/FunctionRequirement.swift
+++ b/Sources/SwiftTypeReader/Entity/FunctionRequirement.swift
@@ -11,8 +11,8 @@ public struct FunctionRequirement {
         public var label: String?
         public var name: String
 
-        public func type() throws -> SType {
-            try unresolvedType.resolved()
+        public func type() -> SType {
+            unresolvedType.resolved()
         }
         public var unresolvedType: SType
     }
@@ -41,8 +41,8 @@ public struct FunctionRequirement {
 
     public var parameters: [Parameter]
 
-    public func outputType() throws -> SType? {
-        try unresolvedOutputType?.resolved()
+    public func outputType() -> SType? {
+        unresolvedOutputType?.resolved()
     }
     public var unresolvedOutputType: SType?
 

--- a/Sources/SwiftTypeReader/Entity/Module.swift
+++ b/Sources/SwiftTypeReader/Entity/Module.swift
@@ -57,8 +57,8 @@ public final class Module {
         }
     }
 
-    public func resolve(location: Location) throws -> Element? {
-        try LocationResolver(context: context)
+    public func resolve(location: Location) -> Element? {
+        LocationResolver(context: context)
             .resolve(module: self, location: location)
     }
 

--- a/Sources/SwiftTypeReader/Entity/PropertyRequirement.swift
+++ b/Sources/SwiftTypeReader/Entity/PropertyRequirement.swift
@@ -20,8 +20,8 @@ public struct PropertyRequirement {
 
     public var name: String
 
-    public func type() throws -> SType {
-        try unresolvedType.resolved()
+    public func type() -> SType {
+        unresolvedType.resolved()
     }
 
     public var unresolvedType: SType

--- a/Sources/SwiftTypeReader/Entity/StoredProperty.swift
+++ b/Sources/SwiftTypeReader/Entity/StoredProperty.swift
@@ -9,8 +9,8 @@ public struct StoredProperty {
 
     public var name: String
 
-    public func type() throws -> SType {
-        try unresolvedType.resolved()
+    public func type() -> SType {
+        unresolvedType.resolved()
     }
 
     public var unresolvedType: SType

--- a/Sources/SwiftTypeReader/Entity/TypeSpecifier.swift
+++ b/Sources/SwiftTypeReader/Entity/TypeSpecifier.swift
@@ -5,8 +5,8 @@ public struct TypeSpecifier: CustomStringConvertible {
         public var name: String
         public var unresolvedGenericArguments: TypeCollection
 
-        public func genericArguments() throws -> [SType] {
-            try unresolvedGenericArguments.resolved()
+        public func genericArguments() -> [SType] {
+            unresolvedGenericArguments.resolved()
         }
 
         public var genericArgumentSpecifiers: [TypeSpecifier] {
@@ -60,7 +60,7 @@ public struct TypeSpecifier: CustomStringConvertible {
     }
 
     public init(
-        module: Module?,
+        module: Module,
         file: URL?,
         location: Location,
         elements: [Element]
@@ -72,28 +72,26 @@ public struct TypeSpecifier: CustomStringConvertible {
         self.elements = elements
     }
 
-    public weak var module: Module?
+    public unowned var module: Module
     public var file: URL?
     public var location: Location
     public var elements: [Element]
 
-    public var lastElement: Element { elements.last! }
+    public var lastElement: Element {
+        get { elements[elements.count - 1] }
+        set { elements[elements.count - 1] = newValue }
+    }
 
     public var description: String {
         return elements.map { $0.description }.joined(separator: ".")
     }
 
-    public func resolve() throws -> SType {
-        guard let module = self.module else {
-            throw MessageError("no Module")
-        }
-        
-        return try TypeResolver(module: module)(specifier: self)
+    public func resolve() -> SType {
+        return TypeResolver(module: module)(specifier: self)
     }
 
     public mutating func removeModuleElement() -> Module? {
-        if let module = self.module,
-           let first = elements.first,
+        if let first = elements.first,
            let element = module.get(name: first.name),
            case .module(let module) = element
         {

--- a/Sources/SwiftTypeReader/Type/EnumType.swift
+++ b/Sources/SwiftTypeReader/Type/EnumType.swift
@@ -23,7 +23,7 @@ public struct EnumType: RegularTypeProtocol {
         self.types = types
     }
 
-    public weak var module: Module?
+    public unowned var module: Module
     public var file: URL?
     public var location: Location
     public var name: String
@@ -33,8 +33,8 @@ public struct EnumType: RegularTypeProtocol {
     public var caseElements: [CaseElement]
     public var types: [SType]
 
-    public func genericArguments() throws -> [SType] {
-        try unresolvedGenericArguments.resolved()
+    public func genericArguments() -> [SType] {
+        unresolvedGenericArguments.resolved()
     }
 
     public mutating func setGenericArguments(_ ts: [SType]) {
@@ -45,7 +45,7 @@ public struct EnumType: RegularTypeProtocol {
         unresolvedGenericArguments.asSpecifiers()
     }
 
-    public func inheritedTypes() throws -> [SType] {
-        try unresolvedInheritedTypes.resolved()
+    public func inheritedTypes() -> [SType] {
+        unresolvedInheritedTypes.resolved()
     }
 }

--- a/Sources/SwiftTypeReader/Type/GenericParameterType.swift
+++ b/Sources/SwiftTypeReader/Type/GenericParameterType.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct GenericParameterType: RegularTypeProtocol {
     public init(
-        module: Module?,
+        module: Module,
         file: URL?,
         location: Location,
         name: String
@@ -13,17 +13,17 @@ public struct GenericParameterType: RegularTypeProtocol {
         self.name = name
     }
 
-    public weak var module: Module?
+    public unowned var module: Module
     public var file: URL?
     public var location: Location
     public var name: String
 
     public var genericParameters: [GenericParameterType] { [] }
 
-    public func genericArguments() throws -> [SType] { [] }
+    public func genericArguments() -> [SType] { [] }
     public var genericArgumentSpecifiers: [TypeSpecifier] { [] }
 
-    public func inheritedTypes() throws -> [SType] { [] }
+    public func inheritedTypes() -> [SType] { [] }
 
     public var types: [SType] { [] }
 

--- a/Sources/SwiftTypeReader/Type/ProtocolType.swift
+++ b/Sources/SwiftTypeReader/Type/ProtocolType.swift
@@ -6,7 +6,7 @@ import Foundation
  */
 public struct ProtocolType: RegularTypeProtocol {
     public init(
-        module: Module?,
+        module: Module,
         file: URL?,
         location: Location,
         name: String,
@@ -25,7 +25,7 @@ public struct ProtocolType: RegularTypeProtocol {
         self.associatedTypes = associatedTypes
     }
 
-    public weak var module: Module?
+    public unowned var module: Module
     public var file: URL?
     public var location: Location
     public var name: String
@@ -36,11 +36,11 @@ public struct ProtocolType: RegularTypeProtocol {
 
     public var genericParameters: [GenericParameterType] { [] }
 
-    public func genericArguments() throws -> [SType] { [] }
+    public func genericArguments() -> [SType] { [] }
     public var genericArgumentSpecifiers: [TypeSpecifier] { [] }
 
-    public func inheritedTypes() throws -> [SType] {
-        try unresolvedInheritedTypes.resolved()
+    public func inheritedTypes() -> [SType] {
+        unresolvedInheritedTypes.resolved()
     }
 
     public var types: [SType] { [] }

--- a/Sources/SwiftTypeReader/Type/RegularType.swift
+++ b/Sources/SwiftTypeReader/Type/RegularType.swift
@@ -43,14 +43,14 @@ public enum RegularType: RegularTypeProtocol {
         }
     }
 
-    public var module: Module? { inner.module }
+    public var module: Module { inner.module }
     public var file: URL? { inner.file }
     public var location: Location { inner.location }
     public var name: String { inner.name }
     public var genericParameters: [GenericParameterType] { inner.genericParameters }
     public var genericArgumentSpecifiers: [TypeSpecifier] { inner.genericArgumentSpecifiers }
-    public func genericArguments() throws -> [SType] { try inner.genericArguments() }
-    public func inheritedTypes() throws -> [SType] { try inner.inheritedTypes() }
+    public func genericArguments() -> [SType] { inner.genericArguments() }
+    public func inheritedTypes() -> [SType] { inner.inheritedTypes() }
     public var description: String { inner.description }
     public func asSpecifier() -> TypeSpecifier { inner.asSpecifier() }
     public var types: [SType] {
@@ -62,7 +62,7 @@ public enum RegularType: RegularTypeProtocol {
         }
     }
 
-    public func applyingGenericArguments(_ args: [SType]) throws -> RegularType {
+    public func applyingGenericArguments(_ args: [SType]) -> RegularType {
         switch self {
         case .struct(var t):
             t.setGenericArguments(args)
@@ -70,24 +70,23 @@ public enum RegularType: RegularTypeProtocol {
         case .enum(var t):
             t.setGenericArguments(args)
             return .enum(t)
-        case .protocol:
-            throw MessageError("protocol can't be applied generic arguments")
-        case .genericParameter:
-            throw MessageError("generic parameter can't be applied generic arguments")
+        case .protocol,
+                .genericParameter:
+            return self
         }
     }
 }
 
 public protocol RegularTypeProtocol: CustomStringConvertible {
-    var module: Module? { get }
+    var module: Module { get }
     var file: URL? { get }
     var location: Location { get }
     var name: String { get }
     var genericParameters: [GenericParameterType] { get }
     var genericArgumentSpecifiers: [TypeSpecifier] { get }
     var types: [SType] { get }
-    func genericArguments() throws -> [SType]
-    func inheritedTypes() throws -> [SType]
+    func genericArguments() -> [SType]
+    func inheritedTypes() -> [SType]
     func get(name: String) -> SType?
     func asSpecifier() -> TypeSpecifier
 }

--- a/Sources/SwiftTypeReader/Type/SType.swift
+++ b/Sources/SwiftTypeReader/Type/SType.swift
@@ -54,10 +54,10 @@ public struct SType: CustomStringConvertible {
         return x
     }
 
-    public func resolved() throws -> SType {
+    public func resolved() -> SType {
         if case .unresolved(let s) = state {
             // safe even if shared
-            box.value = try s.resolve().state
+            box.value = s.resolve().state
         }
         return self
     }
@@ -69,14 +69,6 @@ public struct SType: CustomStringConvertible {
         }
     }
 
-    public func location() throws -> Location {
-        switch state {
-        case .resolved(let t): return t.location
-        case .unresolved:
-            throw MessageError("location of unresolved type is unknown")
-        }
-    }
-
     public func asSpecifier() -> TypeSpecifier {
         switch state {
         case .resolved(let t): return t.asSpecifier()
@@ -84,10 +76,10 @@ public struct SType: CustomStringConvertible {
         }
     }
 
-    public func genericArguments() throws -> [SType] {
+    public func genericArguments() -> [SType] {
         switch state {
-        case .resolved(let t): return try t.genericArguments()
-        case .unresolved(let t): return try t.lastElement.genericArguments()
+        case .resolved(let t): return t.genericArguments()
+        case .unresolved(let t): return t.lastElement.genericArguments()
         }
     }
 
@@ -98,13 +90,14 @@ public struct SType: CustomStringConvertible {
         }
     }
 
-    public func applyingGenericArguments(_ args: [SType]) throws -> SType {
+    public func applyingGenericArguments(_ args: [SType]) -> SType {
         switch state {
         case .resolved(var t):
-            t = try t.applyingGenericArguments(args)
+            t = t.applyingGenericArguments(args)
             return .resolved(t)
-        case .unresolved:
-            throw MessageError("unresolved type can't be applied generic arguments")
+        case .unresolved(var spec):
+            spec.lastElement.unresolvedGenericArguments = TypeCollection(types: args)
+            return .unresolved(spec)
         }
     }
 

--- a/Sources/SwiftTypeReader/Type/StructType.swift
+++ b/Sources/SwiftTypeReader/Type/StructType.swift
@@ -23,7 +23,7 @@ public struct StructType: RegularTypeProtocol {
         self.types = types
     }
 
-    public weak var module: Module?
+    public unowned var module: Module
     public var file: URL?
     public var location: Location
     public var name: String
@@ -33,8 +33,8 @@ public struct StructType: RegularTypeProtocol {
     public var storedProperties: [StoredProperty]
     public var types: [SType]
 
-    public func genericArguments() throws -> [SType] {
-        try unresolvedGenericArguments.resolved()
+    public func genericArguments() -> [SType] {
+        unresolvedGenericArguments.resolved()
     }
 
     public mutating func setGenericArguments(_ ts: [SType]) {
@@ -45,7 +45,7 @@ public struct StructType: RegularTypeProtocol {
         unresolvedGenericArguments.asSpecifiers()
     }
 
-    public func inheritedTypes() throws -> [SType] {
-        try unresolvedInheritedTypes.resolved()
+    public func inheritedTypes() -> [SType] {
+        unresolvedInheritedTypes.resolved()
     }
 }

--- a/Sources/SwiftTypeReader/Type/TypeCollection.swift
+++ b/Sources/SwiftTypeReader/Type/TypeCollection.swift
@@ -32,11 +32,11 @@ public struct TypeCollection {
         self = .resolved(types)
     }
 
-    public func resolved() throws -> [SType] {
+    public func resolved() -> [SType] {
         if case .unresolved(let ss) = state {
             // safe even if shared
             box.value = .resolved(
-                try ss.map { try $0.resolve() }
+                ss.map { $0.resolve() }
             )
         }
         return self.asTypes()

--- a/Tests/SwiftTypeReaderTests/LocationResolveTests.swift
+++ b/Tests/SwiftTypeReaderTests/LocationResolveTests.swift
@@ -16,28 +16,28 @@ struct A {
 """)
 
         XCTAssertEqual(
-            try context.resolve(
+            context.resolve(
                 location: Location(module: "Swift")
             )?.module?.name,
             "Swift"
         )
 
         XCTAssertEqual(
-            try context.resolve(
+            context.resolve(
                 location: Location(module: "Swift", elements: [.type(name: "Int")])
             )?.type?.asSpecifier().elements,
             [.init(name: "Swift"), .init(name: "Int")]
         )
 
         XCTAssertEqual(
-            try context.resolve(
+            context.resolve(
                 location: Location(module: "main")
             )?.module?.name,
             "main"
         )
 
         XCTAssertEqual(
-            try context.resolve(
+            context.resolve(
                 location: Location(module: "main", elements: [.type(name: "G")])
             )?.type?.asSpecifier().elements,
             [.init(name: "main"), .init(name: "G")]
@@ -45,13 +45,13 @@ struct A {
 
         do {
             let t = try XCTUnwrap(
-                try context.resolve(
+                context.resolve(
                     location: Location(module: "main", elements: [.type(name: "G"), .genericParameter(index: 0)])
                 )?.type
             )
 
             XCTAssertEqual(
-                try t.location(),
+                t.regular?.location,
                 Location(module: "main", elements: [.type(name: "G")])
             )
             XCTAssertEqual(
@@ -61,21 +61,21 @@ struct A {
         }
 
         XCTAssertEqual(
-            try context.resolve(
+            context.resolve(
                 location: Location(module: "main", elements: [.type(name: "A"), .type(name: "B")])
             )?.type?.asSpecifier().elements,
             [.init(name: "main"), .init(name: "A"), .init(name: "B")]
         )
 
         XCTAssertEqual(
-            try context.resolve(
+            context.resolve(
                 location: Location(module: "main", elements: [.type(name: "A"), .type(name: "B"), .type(name: "C")])
             )?.type?.asSpecifier().elements,
             [.init(name: "main"), .init(name: "A"), .init(name: "B"), .init(name: "C")]
         )
 
         XCTAssertEqual(
-            try context.resolve(
+            context.resolve(
                 location: Location(module: "main", elements: [.type(name: "A"), .type(name: "G")])
             )?.type?.asSpecifier().elements,
             [.init(name: "main"), .init(name: "A"), .init(name: "G")]
@@ -83,7 +83,7 @@ struct A {
 
         do {
             let t = try XCTUnwrap(
-                try context.resolve(
+                context.resolve(
                     location: Location(
                         module: "main",
                         elements: [.type(name: "A"), .type(name: "G"), .genericParameter(index: 0)]
@@ -92,7 +92,7 @@ struct A {
             )
 
             XCTAssertEqual(
-                try t.location(),
+                t.regular?.location,
                 Location(module: "main", elements: [.type(name: "A"), .type(name: "G")])
             )
             XCTAssertEqual(

--- a/Tests/SwiftTypeReaderTests/SwiftTypeReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/SwiftTypeReaderTests.swift
@@ -20,12 +20,12 @@ struct S {
         XCTAssertEqual(a.name, "a")
 
         let aType = try XCTUnwrap(a.type().struct)
-        XCTAssertEqual(aType.module?.name, "Swift")
+        XCTAssertEqual(aType.module.name, "Swift")
         XCTAssertEqual(aType.name, "Optional")
-        XCTAssertEqual(try aType.genericArguments().count, 1)
+        XCTAssertEqual(aType.genericArguments().count, 1)
 
         let aWrappedType = try XCTUnwrap(aType.genericArguments()[safe: 0]?.struct)
-        XCTAssertEqual(aWrappedType.module?.name, "Swift")
+        XCTAssertEqual(aWrappedType.module.name, "Swift")
         XCTAssertEqual(aWrappedType.name, "Int")
     }
 
@@ -48,12 +48,12 @@ struct S2 {
 
             let a = try XCTUnwrap(s1.storedProperties[safe: 0])
             XCTAssertEqual(a.name, "a")
-            XCTAssertEqual(try a.type().name, "Int")
+            XCTAssertEqual(a.type().name, "Int")
 
             let b = try XCTUnwrap(s1.storedProperties[safe: 1])
             XCTAssertEqual(b.name, "b")
 
-            let s2 = try XCTUnwrap(try b.type().struct)
+            let s2 = try XCTUnwrap(b.type().struct)
             XCTAssertEqual(s2.name, "S2")
             XCTAssertEqual(s2.storedProperties.count, 1)
         }
@@ -64,7 +64,7 @@ struct S2 {
 
             let a = try XCTUnwrap(s2.storedProperties[safe: 0])
             XCTAssertEqual(a.name, "a")
-            XCTAssertEqual(try a.type().name, "Int")
+            XCTAssertEqual(a.type().name, "Int")
         }
 
     }
@@ -106,7 +106,7 @@ enum E {
 
             let x = try XCTUnwrap(c.associatedValues[safe: 0])
             XCTAssertNil(x.name)
-            XCTAssertEqual(try x.type().name, "Int")
+            XCTAssertEqual(x.type().name, "Int")
         }
 
         do {
@@ -115,11 +115,11 @@ enum E {
 
             let x = try XCTUnwrap(c.associatedValues[safe: 0])
             XCTAssertEqual(x.name, "x")
-            XCTAssertEqual(try x.type().name, "Int")
+            XCTAssertEqual(x.type().name, "Int")
 
             let y = try XCTUnwrap(c.associatedValues[safe: 1])
             XCTAssertEqual(y.name, "y")
-            XCTAssertEqual(try y.type().name, "Int")
+            XCTAssertEqual(y.type().name, "Int")
         }
     }
 
@@ -135,7 +135,7 @@ protocol P: Encodable {
 """)
         let p = try XCTUnwrap(module.types[safe: 0]?.protocol)
 
-        XCTAssertEqual(try p.inheritedTypes().first?.name, "Encodable")
+        XCTAssertEqual(p.inheritedTypes().first?.name, "Encodable")
         XCTAssertEqual(p.associatedTypes, ["T"])
 
         do {
@@ -202,7 +202,7 @@ struct S {
 
         let b = try XCTUnwrap(s.storedProperties[safe: 0])
         XCTAssertEqual(b.name, "b")
-        XCTAssertEqual(try b.type().name, "Int")
+        XCTAssertEqual(b.type().name, "Int")
     }
 
     func testInheritanceClause() throws {
@@ -213,11 +213,11 @@ enum E: Codable {
 """)
         let e = try XCTUnwrap(module.types[safe: 0]?.enum)
 
-        XCTAssertEqual(try e.inheritedTypes().count, 1)
+        XCTAssertEqual(e.inheritedTypes().count, 1)
 
         let c = try XCTUnwrap(e.inheritedTypes()[safe: 0])
         XCTAssertNotNil(c.protocol)
-        XCTAssertEqual(c.protocol?.module?.name, "Swift")
+        XCTAssertEqual(c.protocol?.module.name, "Swift")
         XCTAssertEqual(c.name, "Codable")
     }
 
@@ -263,11 +263,11 @@ struct S {
 
         let x = try XCTUnwrap(s.storedProperties[safe: 0])
         XCTAssertEqual(x.name, "x")
-        XCTAssertEqual(try x.type().description, "A.B")
+        XCTAssertEqual(x.type().description, "A.B")
 
         let y = try XCTUnwrap(s.storedProperties[safe: 1])
         XCTAssertEqual(y.name, "y")
-        XCTAssertEqual(try y.type().description, "A.B.C")
+        XCTAssertEqual(y.type().description, "A.B.C")
     }
 
     func testNestedTypeInStruct() throws {
@@ -365,7 +365,7 @@ protocol P {
         XCTAssertEqual(p.name, "P")
         let f = try XCTUnwrap(p.functionRequirements[safe: 0])
         XCTAssertEqual(f.name, "f")
-        let e = try XCTUnwrap(try f.outputType()?.enum)
+        let e = try XCTUnwrap(f.outputType()?.enum)
         let c = try XCTUnwrap(e.caseElements[safe: 0])
         XCTAssertEqual(c.name, "a")
     }

--- a/Tests/SwiftTypeReaderTests/TypeResolveTests.swift
+++ b/Tests/SwiftTypeReaderTests/TypeResolveTests.swift
@@ -16,7 +16,7 @@ struct A {
         // from top level
 
         XCTAssertEqual(
-            try TypeSpecifier(
+            TypeSpecifier(
                 module: module, file: nil,
                 location: Location(module: "main"),
                 elements: [.init(name: "A")]
@@ -25,7 +25,7 @@ struct A {
         )
 
         XCTAssertEqual(
-            try TypeSpecifier(
+            TypeSpecifier(
                 module: module, file: nil,
                 location: Location(module: "main"),
                 elements: [.init(name: "A"), .init(name: "A")]
@@ -34,7 +34,7 @@ struct A {
         )
 
         XCTAssertEqual(
-            try TypeSpecifier(
+            TypeSpecifier(
                 module: module, file: nil,
                 location: Location(module: "main"),
                 elements: [.init(name: "A"), .init(name: "A"), .init(name: "A")]
@@ -45,7 +45,7 @@ struct A {
         // from A
 
         XCTAssertEqual(
-            try TypeSpecifier(
+            TypeSpecifier(
                 module: module, file: nil,
                 location: Location(module: "main", elements: [.type(name: "A")]),
                 elements: [.init(name: "A")]
@@ -54,7 +54,7 @@ struct A {
         )
 
         XCTAssertEqual(
-            try TypeSpecifier(
+            TypeSpecifier(
                 module: module, file: nil,
                 location: Location(module: "main", elements: [.type(name: "A")]),
                 elements: [.init(name: "A"), .init(name: "A")]
@@ -63,7 +63,7 @@ struct A {
         )
 
         XCTAssertNotNil(
-            try TypeSpecifier(
+            TypeSpecifier(
                 module: module, file: nil,
                 location: Location(module: "main", elements: [.type(name: "A")]),
                 elements: [.init(name: "A"), .init(name: "A"), .init(name: "A")]
@@ -73,7 +73,7 @@ struct A {
         // from A.A
 
         XCTAssertEqual(
-            try TypeSpecifier(
+            TypeSpecifier(
                 module: module, file: nil,
                 location: Location(module: "main", elements: [.type(name: "A"), .type(name: "A")]),
                 elements: [.init(name: "A")]
@@ -82,7 +82,7 @@ struct A {
         )
 
         XCTAssertNotNil(
-            try TypeSpecifier(
+            TypeSpecifier(
                 module: module, file: nil,
                 location: Location(module: "main", elements: [.type(name: "A"), .type(name: "A")]),
                 elements: [.init(name: "A"), .init(name: "A")]
@@ -92,7 +92,7 @@ struct A {
         // Absolute spec is location agnostic
 
         XCTAssertEqual(
-            try TypeSpecifier(
+            TypeSpecifier(
                 module: module, file: nil,
                 location: Location(module: "main"),
                 elements: [.init(name: "main"), .init(name: "A"), .init(name: "A")]
@@ -101,7 +101,7 @@ struct A {
         )
 
         XCTAssertEqual(
-            try TypeSpecifier(
+            TypeSpecifier(
                 module: module, file: nil,
                 location: Location(module: "main", elements: [.type(name: "A")]),
                 elements: [.init(name: "main"), .init(name: "A"), .init(name: "A")]
@@ -110,7 +110,7 @@ struct A {
         )
 
         XCTAssertEqual(
-            try TypeSpecifier(
+            TypeSpecifier(
                 module: module, file: nil,
                 location: Location(module: "main", elements: [.type(name: "A"), .type(name: "A")]),
                 elements: [.init(name: "main"), .init(name: "A"), .init(name: "A")]
@@ -142,7 +142,7 @@ struct A {
         )
 
         XCTAssertEqual(
-            try TypeSpecifier(
+            TypeSpecifier(
                 module: moduleY, file: nil,
                 location: Location(module: "Y"),
                 elements: [.init(name: "Int")]
@@ -151,7 +151,7 @@ struct A {
         )
 
         XCTAssertEqual(
-            try TypeSpecifier(
+            TypeSpecifier(
                 module: moduleX, file: nil,
                 location: Location(module: "X"),
                 elements: [.init(name: "Int")]
@@ -160,7 +160,7 @@ struct A {
         )
 
         XCTAssertEqual(
-            try TypeSpecifier(
+            TypeSpecifier(
                 module: moduleY, file: nil,
                 location: Location(module: "Y", elements: [.type(name: "A")]),
                 elements: [.init(name: "Int")]


### PR DESCRIPTION
この修正をすると、これが nil に備えていた動的なエラーが消せる。
resolveの失敗はそもそも、unresolvedになる事を許容したシステムなので例外を投げる必要はない。

これを考慮して修正してほとんどのthrowsをライブラリから外した。

---

`protocol type` と `generic parameter type` に `generic arguments` を適用する場合の例外に関しては、
操作手順のバグの可能性があるので微妙だったが、
そもそも他の部分でも無効な操作に対して空値を返している部分も多いのと、
これをthrowsにすると結局Resolver系がエラーだらけになるので握り潰す事にした。

この部分は設計として type decl, type, type repの区別をすることで、
不正な操作にならない状況の整理が見込めるので、
将来的に見直す。