### PR TITLE
Add ImportReader

### DIFF
--- a/Sources/SwiftTypeReader/Entity/ImportDecl.swift
+++ b/Sources/SwiftTypeReader/Entity/ImportDecl.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct ImportDecl {
+    public unowned var module: Module
+    public var file: URL?
+    public var location: Location
+    public enum Target {
+        case module(name: String)
+    }
+    public var target: Target
+
+    public init(module: Module, file: URL?, location: Location, target: Target) {
+        self.module = module
+        self.file = file
+        self.location = location
+        self.target = target
+    }
+
+    public var name: String {
+        switch target {
+        case .module(let name):
+            return name
+        }
+    }
+}

--- a/Sources/SwiftTypeReader/Entity/Module.swift
+++ b/Sources/SwiftTypeReader/Entity/Module.swift
@@ -12,6 +12,7 @@ public final class Module {
     public unowned let context: Context
     public var name: String
     public var types: [SType] = []
+    public var imports: [ImportDecl] = []
 
     public func asLocation() -> Location {
         Location(module: name)

--- a/Sources/SwiftTypeReader/Reader/ImportReader.swift
+++ b/Sources/SwiftTypeReader/Reader/ImportReader.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SwiftSyntax
+
+final class ImportReader {
+    private let module: Module
+    private let file: URL?
+    private let location: Location
+
+    init(
+        module: Module,
+        file: URL?,
+        location: Location
+    ) {
+        self.module = module
+        self.file = file
+        self.location = location
+    }
+
+    func read(importDecl: ImportDeclSyntax) -> ImportDecl {
+        return ImportDecl(
+            module: module,
+            file: file,
+            location: location,
+            target: .module(name: importDecl.path.description)
+        )
+    }
+}

--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -36,19 +36,17 @@ public struct Reader {
         let sourceFile: SourceFileSyntax = try SyntaxParser.parse(source: source)
 
         let statements = sourceFile.statements.map { $0.item }
+        let context = Readers.Context(
+            module: module,
+            file: file,
+            location: module.asLocation()
+        )
 
-        for statement in statements {
-            if let decl = statement.as(DeclSyntax.self),
-               let type = Readers.readTypeDeclaration(
-                context: .init(
-                    module: module,
-                    file: file,
-                    location: module.asLocation()
-                ),
-                declaration: decl
-               )
-            {
+        for decl in statements.compactMap({ $0.as(DeclSyntax.self) }) {
+            if let type = Readers.readTypeDeclaration(context: context, declaration: decl) {
                 module.types.append(type)
+            } else if let `import` = Readers.readImportDeclaration(context: context, declaration: decl) {
+                module.imports.append(`import`)
             }
         }
     }

--- a/Sources/SwiftTypeReader/Reader/Readers.swift
+++ b/Sources/SwiftTypeReader/Reader/Readers.swift
@@ -47,6 +47,22 @@ enum Readers {
         }
     }
 
+    static func readImportDeclaration(
+        context: Context,
+        declaration: DeclSyntax
+    ) -> ImportDecl? {
+        if let decl = declaration.as(ImportDeclSyntax.self) {
+            let reader = ImportReader(
+                module: context.module,
+                file: context.file,
+                location: context.location
+            )
+            return reader.read(importDecl: decl)
+        } else {
+            return nil
+        }
+    }
+
     static func readTypeSpecifier(
         context: Context,
         typeSyntax: TypeSyntax

--- a/Tests/SwiftTypeReaderTests/SwiftTypeReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/SwiftTypeReaderTests.swift
@@ -368,5 +368,25 @@ protocol P {
         let e = try XCTUnwrap(f.outputType()?.enum)
         let c = try XCTUnwrap(e.caseElements[safe: 0])
         XCTAssertEqual(c.name, "a")
+        XCTAssertEqual(module.imports[safe: 0]?.name, "MyLib")
+    }
+
+    func testImports() throws {
+        let module = try Reader(
+            context: context
+        ).read(source: """
+import Foo
+@preconcurrency import Bar
+import struct Baz.S
+"""
+        )
+
+        let i0 = try XCTUnwrap(module.imports[safe: 0])
+        XCTAssertEqual(i0.name, "Foo")
+        let i1 = try XCTUnwrap(module.imports[safe: 1])
+        XCTAssertEqual(i1.name, "Bar")
+        let i2 = try XCTUnwrap(module.imports[safe: 2])
+        XCTAssertEqual(i2.name, "Baz.S") // INFO: type importing is not supported yet. this should be treated as TypeSpecifier.
+        // INFO: importKind is not supported yet.
     }
 }


### PR DESCRIPTION
## 需要

読み取ったソースコードが他モジュールへのimport文を持っていた場合に、コード生成した結果のファイルにも同様のimport文を書きたくなるときがある。

例:

- Entityモジュール

```swift
public struct UserID {}
```

- APIDefinitionモジュール

```swift
import Entity

public protocol FooServiceProtocol {
    func foo() -> UserID
}
```

- 生成コード

```swift
// import Entity（ここにimportをいい感じに書けるようにしたい）

struct FooProvider {
    func foo() -> UserID { ... } // compile error! UserID is not found
}
```


## 解決方法

`Module` から、そのモジュールがimportしている定義を取得できるようにする


## 悩み

- SwiftTypeReaderは名前的にはTypeを読み取るのが仕事であるため、importDeclを読み込みのは責務を超えている？
    - このような微妙に手が届いてないケースにはコード生成コードがSwiftSyntaxを直接使うべき？
    - あるいは利便性を考慮してSwiftTypeReaderで読めるようにしてあげるべき？

