### PR TITLE
introduce SourceFile

### DIFF
--- a/Sources/SwiftTypeReader/Entity/Module.swift
+++ b/Sources/SwiftTypeReader/Entity/Module.swift
@@ -80,13 +80,16 @@ private struct StandardLibraryBuilder {
 
     init(context: Context) {
         module = Module(context: context, name: "Swift")
-        source = SourceFile(file: URL(fileURLWithPath: "stdlib.swift"))
+        source = SourceFile(
+            module: module,
+            file: URL(fileURLWithPath: "stdlib.swift")
+        )
     }
 
     mutating func addStruct(name: String) {
         let t = StructType(
             module: module,
-            file: nil,
+            file: source.file,
             location: location,
             name: name
         )
@@ -97,7 +100,7 @@ private struct StandardLibraryBuilder {
     mutating func addProtocol(name: String) {
         let t = ProtocolType(
             module: module,
-            file: nil,
+            file: source.file,
             location: location,
             name: name
         )

--- a/Sources/SwiftTypeReader/Entity/SourceFile.swift
+++ b/Sources/SwiftTypeReader/Entity/SourceFile.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public struct SourceFile {
+    public var file: URL
+    public var types: [SType] = []
+    public var imports: [ImportDecl] = []
+
+    public init(
+        file: URL
+    ) {
+        self.file = file
+    }
+}
+

--- a/Sources/SwiftTypeReader/Entity/SourceFile.swift
+++ b/Sources/SwiftTypeReader/Entity/SourceFile.swift
@@ -1,13 +1,16 @@
 import Foundation
 
 public struct SourceFile {
+    public unowned var module: Module
     public var file: URL
     public var types: [SType] = []
     public var imports: [ImportDecl] = []
 
     public init(
+        module: Module,
         file: URL
     ) {
+        self.module = module
         self.file = file
     }
 }

--- a/Sources/SwiftTypeReader/Reader/EnumReader.swift
+++ b/Sources/SwiftTypeReader/Reader/EnumReader.swift
@@ -3,12 +3,12 @@ import SwiftSyntax
 
 final class EnumReader {
     private let module: Module
-    private let file: URL?
+    private let file: URL
     private let location: Location
 
     init(
         module: Module,
-        file: URL?,
+        file: URL,
         location: Location
     ) {
         self.module = module

--- a/Sources/SwiftTypeReader/Reader/ProtocolReader.swift
+++ b/Sources/SwiftTypeReader/Reader/ProtocolReader.swift
@@ -3,12 +3,12 @@ import SwiftSyntax
 
 final class ProtocolReader {
     private let module: Module
-    private let file: URL?
+    private let file: URL
     private let location: Location
 
     init(
         module: Module,
-        file: URL?,
+        file: URL,
         location: Location
     ) {
         self.module = module

--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -46,7 +46,7 @@ public struct Reader {
             location: module.asLocation()
         )
 
-        var source = SourceFile(file: file)
+        var source = SourceFile(module: module, file: file)
 
         for decl in statements.compactMap({ $0.as(DeclSyntax.self) }) {
             if let type = Readers.readTypeDeclaration(context: context, declaration: decl) {

--- a/Sources/SwiftTypeReader/Reader/Readers.swift
+++ b/Sources/SwiftTypeReader/Reader/Readers.swift
@@ -4,7 +4,7 @@ import SwiftSyntax
 enum Readers {
     struct Context {
         var module: Module
-        var file: URL?
+        var file: URL
         var location: Location
     }
 

--- a/Sources/SwiftTypeReader/Reader/StructReader.swift
+++ b/Sources/SwiftTypeReader/Reader/StructReader.swift
@@ -3,12 +3,12 @@ import SwiftSyntax
 
 final class StructReader {
     private let module: Module
-    private let file: URL?
+    private let file: URL
     private let location: Location
 
     init(
         module: Module,
-        file: URL?,
+        file: URL,
         location: Location
     ) {
         self.module = module

--- a/Sources/SwiftTypeReader/Type/EnumType.swift
+++ b/Sources/SwiftTypeReader/Type/EnumType.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct EnumType: RegularTypeProtocol {
     public init(
         module: Module,
-        file: URL?,
+        file: URL,
         location: Location,
         name: String,
         genericParameters: [GenericParameterType] = [],
@@ -24,7 +24,7 @@ public struct EnumType: RegularTypeProtocol {
     }
 
     public unowned var module: Module
-    public var file: URL?
+    public var file: URL
     public var location: Location
     public var name: String
     public var genericParameters: [GenericParameterType]

--- a/Sources/SwiftTypeReader/Type/GenericParameterType.swift
+++ b/Sources/SwiftTypeReader/Type/GenericParameterType.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct GenericParameterType: RegularTypeProtocol {
     public init(
         module: Module,
-        file: URL?,
+        file: URL,
         location: Location,
         name: String
     ) {
@@ -14,7 +14,7 @@ public struct GenericParameterType: RegularTypeProtocol {
     }
 
     public unowned var module: Module
-    public var file: URL?
+    public var file: URL
     public var location: Location
     public var name: String
 

--- a/Sources/SwiftTypeReader/Type/ProtocolType.swift
+++ b/Sources/SwiftTypeReader/Type/ProtocolType.swift
@@ -7,7 +7,7 @@ import Foundation
 public struct ProtocolType: RegularTypeProtocol {
     public init(
         module: Module,
-        file: URL?,
+        file: URL,
         location: Location,
         name: String,
         inheritedTypes: [TypeSpecifier] = [],
@@ -26,7 +26,7 @@ public struct ProtocolType: RegularTypeProtocol {
     }
 
     public unowned var module: Module
-    public var file: URL?
+    public var file: URL
     public var location: Location
     public var name: String
     public var unresolvedInheritedTypes: TypeCollection

--- a/Sources/SwiftTypeReader/Type/RegularType.swift
+++ b/Sources/SwiftTypeReader/Type/RegularType.swift
@@ -44,7 +44,7 @@ public enum RegularType: RegularTypeProtocol {
     }
 
     public var module: Module { inner.module }
-    public var file: URL? { inner.file }
+    public var file: URL { inner.file }
     public var location: Location { inner.location }
     public var name: String { inner.name }
     public var genericParameters: [GenericParameterType] { inner.genericParameters }
@@ -79,7 +79,7 @@ public enum RegularType: RegularTypeProtocol {
 
 public protocol RegularTypeProtocol: CustomStringConvertible {
     var module: Module { get }
-    var file: URL? { get }
+    var file: URL { get }
     var location: Location { get }
     var name: String { get }
     var genericParameters: [GenericParameterType] { get }

--- a/Sources/SwiftTypeReader/Type/StructType.swift
+++ b/Sources/SwiftTypeReader/Type/StructType.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct StructType: RegularTypeProtocol {
     public init(
         module: Module,
-        file: URL?,
+        file: URL,
         location: Location,
         name: String,
         genericParameters: [GenericParameterType] = [],
@@ -24,7 +24,7 @@ public struct StructType: RegularTypeProtocol {
     }
 
     public unowned var module: Module
-    public var file: URL?
+    public var file: URL
     public var location: Location
     public var name: String
     public var genericParameters: [GenericParameterType]

--- a/Tests/SwiftTypeReaderTests/ReaderTestCaseBase.swift
+++ b/Tests/SwiftTypeReaderTests/ReaderTestCaseBase.swift
@@ -13,6 +13,8 @@ class ReaderTestCaseBase: XCTestCase {
     }
 
     func read(_ source: String, file: StaticString = #file, line: UInt = #line) throws -> Module {
-        return try Reader(context: context!).read(source: source)
+        let reader = Reader(context: context!)
+        _ = try reader.read(source: source, file: URL(fileURLWithPath: "test.swift"))
+        return reader.module
     }
 }

--- a/Tests/SwiftTypeReaderTests/SwiftTypeReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/SwiftTypeReaderTests.swift
@@ -343,22 +343,26 @@ struct C {
         _ = try Reader(
             context: context,
             module: context.getOrCreateModule(name: "MyLib")
-        ).read(source: """
+        ).read(
+            source: """
 public enum E {
     case a
 }
-"""
+""",
+            file: URL(fileURLWithPath: "MyLib.swift")
         )
 
         let module = try Reader(
             context: context
-        ).read(source: """
+        ).read(
+            source: """
 import MyLib
 
 protocol P {
     func f() -> E
 }
-"""
+""",
+            file: URL(fileURLWithPath: "main.swift")
         )
 
         let p = try XCTUnwrap(module.types[safe: 0]?.protocol)
@@ -372,20 +376,22 @@ protocol P {
     }
 
     func testImports() throws {
-        let module = try Reader(
+        let source = try Reader(
             context: context
-        ).read(source: """
+        ).read(
+            source: """
 import Foo
 @preconcurrency import Bar
 import struct Baz.S
-"""
+""",
+            file: URL(fileURLWithPath: "main.swift")
         )
 
-        let i0 = try XCTUnwrap(module.imports[safe: 0])
+        let i0 = try XCTUnwrap(source.imports[safe: 0])
         XCTAssertEqual(i0.name, "Foo")
-        let i1 = try XCTUnwrap(module.imports[safe: 1])
+        let i1 = try XCTUnwrap(source.imports[safe: 1])
         XCTAssertEqual(i1.name, "Bar")
-        let i2 = try XCTUnwrap(module.imports[safe: 2])
+        let i2 = try XCTUnwrap(source.imports[safe: 2])
         XCTAssertEqual(i2.name, "Baz.S") // INFO: type importing is not supported yet. this should be treated as TypeSpecifier.
         // INFO: importKind is not supported yet.
     }

--- a/Tests/SwiftTypeReaderTests/TypeResolveTests.swift
+++ b/Tests/SwiftTypeReaderTests/TypeResolveTests.swift
@@ -120,25 +120,31 @@ struct A {
     }
 
     func testCrossModuleResolve() throws {
-        let moduleX = try Reader(
+        let moduleX = context.getOrCreateModule(name: "X")
+        _ = try Reader(
             context: context,
-            module: context.getOrCreateModule(name: "X")
-        ).read(source: """
+            module: moduleX
+        ).read(
+            source: """
 struct Int {
 }
-"""
+""",
+            file: URL(fileURLWithPath: "x.swift")
         )
 
-        let moduleY = try Reader(
+        let moduleY = context.getOrCreateModule(name: "Y")
+        _ = try Reader(
             context: context,
-            module: context.getOrCreateModule(name: "Y")
-        ).read(source: """
+            module: moduleY
+        ).read(
+            source: """
 struct A {
     struct Int {
 
     }
 }
-"""
+""",
+            file: URL(fileURLWithPath: "y.swift")
         )
 
         XCTAssertEqual(


### PR DESCRIPTION
#18 に対応します。

`SourceFile` を導入して、 `Reader.read` がそれを返すようにします。
`read` の `file:` 引数は必須に変えました。

`Module.types` は下位互換なcomputed propertyを生やします。