### PR TITLE
SwiftSyntaxをアップグレードする

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
-        "version" : "0.50600.1"
+        "revision" : "72d3da66b085c2299dd287c2be3b92b5ebd226de",
+        "version" : "0.50700.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax", exact: "0.50600.1"),
+        .package(url: "https://github.com/apple/swift-syntax", exact: "0.50700.1"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.0.3")
     ],
     targets: [


### PR DESCRIPTION
swift 5.6 用のswift syntaxだとLinux CIが通らないっぽい