### PR TITLE
Scan top level function decl

### DIFF
--- a/Sources/SwiftTypeReader/Decl/SourceFile.swift
+++ b/Sources/SwiftTypeReader/Decl/SourceFile.swift
@@ -9,6 +9,7 @@ public final class SourceFile: Decl & DeclContext {
         self.file = file
         self.imports = []
         self.types = []
+        self.funcs = []
     }
 
     public unowned var module: Module
@@ -17,6 +18,7 @@ public final class SourceFile: Decl & DeclContext {
 
     public var imports: [ImportDecl]
     public var types: [any GenericTypeDecl]
+    public var funcs: [FuncDecl]
 
     public func find(name: String, options: LookupOptions) -> (any Decl)? {
         if options.type {
@@ -30,6 +32,11 @@ public final class SourceFile: Decl & DeclContext {
                     return false
                 }
             }) {
+                return type
+            }
+        }
+        if options.value {
+            if let type = funcs.first(where: { $0.name == name }) {
                 return type
             }
         }

--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -61,6 +61,8 @@ public struct Reader {
                 source.types.append(type)
             } else if let `import` = readImport(decl: decl, on: source) {
                 source.imports.append(`import`)
+            } else if let `func` = readFunc(decl: decl, on: source) {
+                source.funcs.append(`func`)
             }
         }
 
@@ -385,7 +387,7 @@ public struct Reader {
     static func readFunc(
         function functionSyntax: FunctionDeclSyntax,
         on context: any DeclContext
-    ) -> FuncDecl? {
+    ) -> FuncDecl {
         let name = functionSyntax.identifier.text
 
         var modifiers = ModifierReader()

--- a/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
@@ -78,7 +78,7 @@ struct S {
         let module = try read("""
 struct S1 {
     var a: Int
-    var b: S2
+    func b() -> S2 {}
 }
 
 public struct S2 {
@@ -95,10 +95,10 @@ public struct S2 {
             XCTAssertEqual(a.name, "a")
             XCTAssertEqual(a.interfaceType.asNominal?.name, "Int")
 
-            let b = try XCTUnwrap(s1.find(name: "b")?.asVar)
+            let b = try XCTUnwrap(s1.find(name: "b")?.asFunc)
             XCTAssertEqual(b.name, "b")
 
-            let s2 = try XCTUnwrap(b.interfaceType.asStruct)
+            let s2 = try XCTUnwrap(b.resultInterfaceType.asStruct)
             XCTAssertEqual(s2.decl.name, "S2")
             XCTAssertEqual(s2.decl.storedProperties.count, 1)
         }
@@ -897,5 +897,16 @@ struct D {
         let b = try XCTUnwrap(d.find(name: "b")?.asVar)
         let bt = try XCTUnwrap(b.interfaceType.asTypeAlias)
         XCTAssertEqual(bt.underlyingType.description, "K<Int, Bool>")
+    }
+
+    func testTopLevelFunc() throws {
+        let module = try read("""
+public func f() {
+}
+""")
+
+        let f = try XCTUnwrap(module.find(name: "f")?.asFunc)
+        XCTAssertTrue(f.modifiers.contains(.public))
+        XCTAssertEqual(f.parameters, [])
     }
 }


### PR DESCRIPTION
以下のような、トップレベルに存在する関数をスキャンできていなかったので、スキャンできるようにします。

```
import Foundation

public func f() {
}
```