### PR TITLE
Add InitDecl

### DIFF
--- a/Sources/SwiftTypeReader/Decl/Decl.swift
+++ b/Sources/SwiftTypeReader/Decl/Decl.swift
@@ -14,6 +14,7 @@ extension Decl {
     public var asGenericParam: GenericParamDecl? { self as? GenericParamDecl }
     public var asGenericType: (any GenericTypeDecl)? { self as? any GenericTypeDecl }
     public var asImport: ImportDecl? { self as? ImportDecl }
+    public var asInit: InitDecl? { self as? InitDecl }
     public var asModule: Module? { self as? Module }
     public var asNominalType: (any NominalTypeDecl)? { self as? any NominalTypeDecl }
     public var asParam: ParamDecl? { self as? ParamDecl }

--- a/Sources/SwiftTypeReader/Decl/DeclContext.swift
+++ b/Sources/SwiftTypeReader/Decl/DeclContext.swift
@@ -10,6 +10,7 @@ extension DeclContext {
     public var asFunc: FuncDecl? { self as? FuncDecl }
     public var asGenericContext: (any GenericContext)? { self as? any GenericContext }
     public var asGenericType: (any GenericTypeDecl)? { self as? any GenericTypeDecl }
+    public var asInit: InitDecl? { self as? InitDecl }
     public var asModule: Module? { self as? Module }
     public var asNominalType: (any NominalTypeDecl)? { self as? any NominalTypeDecl }
     public var asProtocol: ProtocolDecl? { self as? ProtocolDecl }

--- a/Sources/SwiftTypeReader/Decl/InitDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/InitDecl.swift
@@ -1,0 +1,27 @@
+public final class InitDecl: ValueDecl & DeclContext {
+    public init(
+        context: any DeclContext,
+        modifiers: [DeclModifier]
+    ) {
+        self.context = context
+        self.modifiers = modifiers
+        self.parameters = []
+    }
+
+    public unowned var context: any DeclContext
+    public var parentContext: (any DeclContext)? { context }
+    public var modifiers: [DeclModifier]
+    public var valueName: String? { nil }
+
+    public var parameters: [ParamDecl]
+
+    public func find(name: String, options: LookupOptions) -> (any Decl)? {
+        if options.value {
+            if let decl = parameters.first(where: { $0.name == name }) {
+                return decl
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/SwiftTypeReader/Decl/NominalTypeDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/NominalTypeDecl.swift
@@ -19,6 +19,10 @@ extension NominalTypeDecl {
         members.compactMap { $0.asVar }
     }
 
+    public var initializers: [InitDecl] {
+        members.compactMap { $0.asInit }
+    }
+
     public var functions: [FuncDecl] {
         members.compactMap { $0.asFunc }
     }

--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -86,6 +86,8 @@ public struct Reader {
             return vars
         } else if let `func` = readFunc(decl: decl, on: context) {
             return [`func`]
+        } else if let `init` = readInit(decl: decl, on: context) {
+            return [`init`]
         } else if let cases = readCaseElements(decl: decl, on: context) {
             return cases
         } else if let associatedType = readAssociatedType(decl: decl, on: context) {
@@ -410,6 +412,29 @@ public struct Reader {
         }
 
         return `func`
+    }
+
+    static func readInit(decl: DeclSyntax, on context: any DeclContext) -> InitDecl? {
+        guard let decl = decl.as(InitializerDeclSyntax.self) else { return nil }
+        return readInit(initializer: decl, on: context)
+    }
+
+    static func readInit(
+        initializer initializerSyntax: InitializerDeclSyntax,
+        on context: any DeclContext
+    ) -> InitDecl {
+        var modifiers = ModifierReader()
+        modifiers.read(decls: initializerSyntax.modifiers)
+//        modifiers.read(token: initializerSyntax.asyncOrReasyncKeyword) // FIXME: not supported in SwiftSyntax 0.50700.1
+        modifiers.read(token: initializerSyntax.throwsOrRethrowsKeyword)
+
+        let `init` = InitDecl(context: context, modifiers: modifiers.modifiers)
+
+        `init`.parameters = initializerSyntax.parameters.parameterList.compactMap { (param) in
+            readParam(param: param, on: `init`)
+        }
+
+        return `init`
     }
 
     static func readModifires(

--- a/Sources/codegen/Definitions.swift
+++ b/Sources/codegen/Definitions.swift
@@ -67,6 +67,7 @@ struct Definitions {
         .init(.decl, "genericParam", "type"),
         .init(.decl, "genericType", "type", attributes: [.protocol, .declContext]),
         .init(.decl, "import"),
+        .init(.decl, "init", "value", attributes: [.declContext]),
         .init(.decl, "module", "type", typeName: "Module", attributes: [.declContext]),
         .init(.decl, "nominalType", "genericType", attributes: [.protocol]),
         .init(.decl, "param", "value"),

--- a/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
@@ -909,4 +909,26 @@ public func f() {
         XCTAssertTrue(f.modifiers.contains(.public))
         XCTAssertEqual(f.parameters, [])
     }
+
+    func testInitializer() throws {
+        let module = try read("""
+struct S {
+    init() {}
+}
+class C {
+    init(a: Int) throws {}
+}
+""")
+
+        let s = try XCTUnwrap(module.find(name: "S")?.asStruct)
+        XCTAssertEqual(s.initializers.count, 1)
+        XCTAssertEqual(s.initializers[safe: 0]?.parameters.count, 0)
+
+        let c = try XCTUnwrap(module.find(name: "C")?.asClass)
+        XCTAssertEqual(c.initializers.count, 1)
+        XCTAssertEqual(c.initializers[safe: 0]?.parameters.count, 1)
+        XCTAssertEqual(c.initializers[safe: 0]?.parameters[safe: 0]?.typeRepr.description, "Int")
+        XCTAssertEqual(c.initializers[safe: 0]?.modifiers.contains(.throws), true)
+        XCTAssertEqual(c.initializers[safe: 0]?.interfaceType.description, "(Int) throws -> C")
+    }
 }


### PR DESCRIPTION
`InitializerDeclSyntax`を読み取っていなかったので、読み取るようにします。
initializerが`ValueDecl`かどうかはよく分かりませんでした。Functionなどと同列かと思い`members`に保持できるよう`ValueDecl`ということにしています。

```swift
struct S {
    init() {}
}
class C {
    init(a: Int) throws {}
}
```