### PR TITLE
Remove CodegenKit dependency from SwiftTypeReader

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,6 @@ let package = Package(
             dependencies: [
                 .product(name: "SwiftSyntaxParser", package: "swift-syntax"),
                 .product(name: "Collections", package: "swift-collections"),
-                .product(name: "CodegenKit", package: "CodegenKit"),
             ]
         ),
         .testTarget(

--- a/Sources/SwiftTypeReader/Basic/FileManagerEnumerateRelativePath.swift
+++ b/Sources/SwiftTypeReader/Basic/FileManagerEnumerateRelativePath.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+extension FileManager {
+    func enumerateRelative(
+        path: URL,
+        options: Set<EnumerateRelativePath.Option>
+    ) -> EnumerateRelativePath {
+        return EnumerateRelativePath(fileManager: self, base: path, options: options)
+    }
+}
+
+struct EnumerateRelativePath: Sequence {
+    enum Option {
+        case skipsHiddenFiles
+    }
+
+    typealias Element = URL
+
+    var fileManager: FileManager
+    var base: URL
+    var options: Set<Option>
+
+    struct Iterator: IteratorProtocol {
+        var sequence: EnumerateRelativePath
+        var enumerator: FileManager.DirectoryEnumerator?
+
+        func next() -> URL? {
+            guard let enumerator else { return nil }
+
+            while true {
+                guard let path = enumerator.nextObject() as? String else { return nil }
+
+                if sequence.options.contains(.skipsHiddenFiles), path.hasPrefix(".") {
+                    continue
+                }
+
+                return URL(fileURLWithPath: path, relativeTo: sequence.base)
+            }
+        }
+    }
+
+    func makeIterator() -> Iterator {
+        return Iterator(
+            sequence: self,
+            enumerator: fileManager.enumerator(atPath: base.relativePath)
+        )
+    }
+}

--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -1,7 +1,6 @@
 import Foundation
 import SwiftSyntax
 import SwiftSyntaxParser
-import CodegenKit
 
 public struct Reader {
     public var context: Context


### PR DESCRIPTION
SwiftTypeReaderがライブラリラーゲットとしてもCodegenKitに依存している部分を無くします。

CodegenKitの依存であるswift-syntaxがダブっていたり、swift-formatに依存する点がポータビリティに欠けるので外しておきたいです。