### PR TITLE
Read modifiers of typealias

### DIFF
--- a/Sources/SwiftTypeReader/Decl/TypeAliasDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/TypeAliasDecl.swift
@@ -5,6 +5,7 @@ public final class TypeAliasDecl: GenericTypeDecl {
         underlyingTypeRepr: any TypeRepr
     ) {
         self.context = context
+        self.modifiers = []
         self.name = name
         self.syntaxGenericParams = .init()
         self.underlyingTypeRepr = underlyingTypeRepr
@@ -12,6 +13,7 @@ public final class TypeAliasDecl: GenericTypeDecl {
 
     public unowned var context: any DeclContext
     public var parentContext: (any DeclContext)? { context }
+    public var modifiers: [DeclModifier]
     public var name: String
     public var valueName: String? { name }
     public var syntaxGenericParams: GenericParamList

--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -522,6 +522,8 @@ public struct Reader {
             underlyingTypeRepr: underlying
         )
 
+        alias.modifiers = readModifires(decls: decl.modifiers)
+
         alias.syntaxGenericParams = readGenericParamList(clause: decl.genericParameterClause, on: alias)
 
         return alias

--- a/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
@@ -734,7 +734,7 @@ protocol P {
 
     func testTopLevelTypeAlias() throws {
         let module = try read("""
-typealias A = Int
+public typealias A = Int
 """
         )
 
@@ -743,6 +743,7 @@ typealias A = Int
         XCTAssertEqual(ad.genericParams.items.count, 0)
         XCTAssertEqual(ad.contextGenericSignature.description, "")
         XCTAssertEqual(ad.underlyingType.description, "Int")
+        XCTAssertTrue(ad.modifiers.contains(.public))
 
         let a = try XCTUnwrap(ad.declaredInterfaceType.asTypeAlias)
         XCTAssertEqual(a.description, "A")


### PR DESCRIPTION
`TypeAliasDecl` が`public` などのModifierを読み取っていなかったので読み取るようにします。

`var modifiers: [DeclModifier]` を持ってるDeclはかなり多いのでprotocolを用意して取り出しやすくしてもいいかもしれませんね