### PR TITLE
Unescape identifier for enum case

### DIFF
--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -228,7 +228,7 @@ public struct Reader {
         element elementSyntax: EnumCaseElementSyntax,
         on enum: EnumDecl
     ) -> EnumCaseElementDecl {
-        let name = elementSyntax.identifier.text
+        let name = Reader.unescapeIdentifier(elementSyntax.identifier.text)
 
         var rawValue: EnumCaseElementDecl.LiteralExpr?
         if let string = elementSyntax.rawValue?.value.as(StringLiteralExprSyntax.self),

--- a/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
@@ -1008,4 +1008,21 @@ func f6(e _: Int) {}
         XCTAssertEqual(f6Param0.syntaxName, "_")
         XCTAssertEqual(f6Param0.interfaceName, "e")
     }
+
+    func testUnescapeIdentifier() throws {
+        let module = read("""
+struct S {
+    var `class`: Int
+}
+enum E {
+    case `class`
+}
+""")
+
+        let s = try XCTUnwrap(module.find(name: "S")?.asStruct)
+        XCTAssertEqual(s.storedProperties[safe: 0]?.name, "class")
+
+        let e = try XCTUnwrap(module.find(name: "E")?.asEnum)
+        XCTAssertEqual(e.caseElements[safe: 0]?.name, "class")
+    }
 }


### PR DESCRIPTION
structやclassのプロパティにおいては名前にバッククォートが利用されていた場合に自動でアンエスケープされていましたが、enumのcaseにおいてはアンエスケープされていませんでした。
利用側でバッククォートが残ったままになっているため、こちらもアンエスケープするように修正します

```swift
enum E {
  case `class` // EnumCaseElementDecl(name="`class`")😧
}
```