### PR TITLE
Composition type

### DIFF
--- a/Sources/SwiftTypeReader/Decl/StandardLibraryBuilder.swift
+++ b/Sources/SwiftTypeReader/Decl/StandardLibraryBuilder.swift
@@ -72,6 +72,11 @@ struct StandardLibraryBuilder {
         addProtocol(name: "Decodable")
         addProtocol(name: "Codable")
         addProtocol(name: "Sendable")
+        addProtocol(name: "Hashable")
+        addProtocol(name: "Equatable")
+        addProtocol(name: "RawRepresentable")
+        addProtocol(name: "Error")
+        addProtocol(name: "Identifiable")
 
         module.sources.append(source)
 

--- a/Sources/SwiftTypeReader/Decl/TypeDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/TypeDecl.swift
@@ -4,7 +4,17 @@ public protocol TypeDecl: ValueDecl {
 
 extension TypeDecl {
     public var inheritedTypes: [any SType] {
-        inheritedTypeReprs.map { $0.resolve(from: innermostContext) }
+        func unwrap(repr: any TypeRepr) -> [any TypeRepr] {
+            if let tuple = repr.asTuple {
+                return tuple.elements.flatMap(unwrap(repr:))
+            } else if let composition = repr.asComposition {
+                return composition.elements.flatMap(unwrap(repr:))
+            } else {
+                return [repr]
+            }
+        }
+        return inheritedTypeReprs.flatMap(unwrap(repr:))
+            .map { $0.resolve(from: innermostContext) }
     }
 
     public var declaredInterfaceType: any SType {

--- a/Sources/SwiftTypeReader/Reader/TypeReprReader.swift
+++ b/Sources/SwiftTypeReader/Reader/TypeReprReader.swift
@@ -21,6 +21,10 @@ struct TypeReprReader {
             return read(member: member)
         } else if let simple = type.as(SimpleTypeIdentifierSyntax.self) {
             return read(simple: simple)
+        } else if let composition = type.as(CompositionTypeSyntax.self) {
+            return read(composition: composition)
+        } else if let tuple = type.as(TupleTypeSyntax.self) {
+            return read(tuple: tuple)
         } else if let optional = type.as(OptionalTypeSyntax.self) {
             return read(optional: optional)
         } else if let array = type.as(ArrayTypeSyntax.self) {
@@ -61,6 +65,22 @@ struct TypeReprReader {
         return IdentTypeRepr(
             name: simple.name.text,
             genericArgs: args
+        )
+    }
+
+    static func read(composition: CompositionTypeSyntax) -> (any TypeRepr)? {
+        return CompositionTypeRepr(
+            elements: composition.elements.compactMap { (element) in
+                read(type: element.type)
+            }
+        )
+    }
+
+    static func read(tuple: TupleTypeSyntax) -> (any TypeRepr)? {
+        return TupleTypeRepr(
+            elements: tuple.elements.compactMap { (element) in
+                read(type: element.type)
+            }
         )
     }
 

--- a/Sources/SwiftTypeReader/TypeRepr/CompositionTypeRepr.swift
+++ b/Sources/SwiftTypeReader/TypeRepr/CompositionTypeRepr.swift
@@ -1,0 +1,13 @@
+public struct CompositionTypeRepr: TypeRepr {
+    public init(
+        elements: [any TypeRepr]
+    ) {
+        self.elements = elements
+    }
+
+    @AnyTypeReprArrayStorage public var elements: [any TypeRepr]
+
+    public var description: String {
+        return elements.map { $0.description }.joined(separator: " & ")
+    }
+}

--- a/Sources/SwiftTypeReader/TypeRepr/TypeRepr.swift
+++ b/Sources/SwiftTypeReader/TypeRepr/TypeRepr.swift
@@ -8,6 +8,7 @@ extension TypeRepr {
     public var asIdent: IdentTypeRepr? { self as? IdentTypeRepr }
     public var asMetatype: MetatypeTypeRepr? { self as? MetatypeTypeRepr }
     public var asTuple: TupleTypeRepr? { self as? TupleTypeRepr }
+    public var asComposition: CompositionTypeRepr? { self as? CompositionTypeRepr }
     // @end
 
     public func resolve(from context: any DeclContext) -> any SType {

--- a/Sources/codegen/Definitions.swift
+++ b/Sources/codegen/Definitions.swift
@@ -108,7 +108,8 @@ struct Definitions {
         .init(.typeRepr, "function"),
         .init(.typeRepr, "ident"),
         .init(.typeRepr, "metatype"),
-        .init(.typeRepr, "tuple")
+        .init(.typeRepr, "tuple"),
+        .init(.typeRepr, "composition"),
     ]
 
     func nodes(kind: Node.Kind) -> [Node] {


### PR DESCRIPTION
`inheritedTypes`において、tuple typeとcomposition typeを考慮できていなかったので考慮するようにします。

以下のような定義において、3つのプロトコルまたはクラスを正確に抽出できるようにします。

```swift
enum E: (Encodable & (Decodable)) & C {
}
```