### PR TITLE
Add comment property to NominalType

### DIFF
--- a/Sources/SwiftTypeReader/Decl/ClassDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/ClassDecl.swift
@@ -4,6 +4,7 @@ public final class ClassDecl: NominalTypeDecl {
         name: String
     ) {
         self.context = context
+        self.comment = ""
         self.modifiers = []
         self.name = name
         self.syntaxGenericParams = .init()
@@ -13,6 +14,7 @@ public final class ClassDecl: NominalTypeDecl {
 
     public unowned var context: any DeclContext
     public var parentContext: (any DeclContext)? { context }
+    public var comment: String
     public var modifiers: [DeclModifier]
     public var name: String
     public var syntaxGenericParams: GenericParamList

--- a/Sources/SwiftTypeReader/Decl/EnumDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/EnumDecl.swift
@@ -4,6 +4,7 @@ public final class EnumDecl: NominalTypeDecl {
         name: String
     ) {
         self.context = context
+        self.comment = ""
         self.modifiers = []
         self.name = name
         self.syntaxGenericParams = .init()
@@ -13,6 +14,7 @@ public final class EnumDecl: NominalTypeDecl {
 
     public unowned var context: any DeclContext
     public var parentContext: (any DeclContext)? { context }
+    public var comment: String
     public var modifiers: [DeclModifier]
     public var name: String
     public var syntaxGenericParams: GenericParamList

--- a/Sources/SwiftTypeReader/Decl/NominalTypeDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/NominalTypeDecl.swift
@@ -1,4 +1,5 @@
 public protocol NominalTypeDecl: GenericTypeDecl {
+    var comment: String { get }
     var name: String { get }
     var members: [any ValueDecl] { get }
 

--- a/Sources/SwiftTypeReader/Decl/ProtocolDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/ProtocolDecl.swift
@@ -4,6 +4,7 @@ public final class ProtocolDecl: NominalTypeDecl {
         name: String
     ) {
         self.context = context
+        self.comment = ""
         self.modifiers = []
         self.name = name
         self.inheritedTypeReprs = []
@@ -12,6 +13,7 @@ public final class ProtocolDecl: NominalTypeDecl {
 
     public unowned var context: any DeclContext
     public var parentContext: (any DeclContext)? { context }
+    public var comment: String
     public var modifiers: [DeclModifier]
     public var name: String
     public var syntaxGenericParams: GenericParamList { .init() }

--- a/Sources/SwiftTypeReader/Decl/StructDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/StructDecl.swift
@@ -4,6 +4,7 @@ public final class StructDecl: NominalTypeDecl {
         name: String
     ) {
         self.context = context
+        self.comment = ""
         self.modifiers = []
         self.name = name
         self.syntaxGenericParams = .init()
@@ -13,6 +14,7 @@ public final class StructDecl: NominalTypeDecl {
 
     public unowned var context: any DeclContext
     public var parentContext: (any DeclContext)? { context }
+    public var comment: String
     public var modifiers: [DeclModifier]
     public var name: String
     public var syntaxGenericParams: GenericParamList

--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -153,6 +153,8 @@ public struct Reader {
 
         let `enum` = EnumDecl(context: context, name: name)
 
+        `enum`.comment = enumSyntax.leadingTrivia.description
+
         `enum`.modifiers = readModifires(decls: enumSyntax.modifiers)
 
         `enum`.syntaxGenericParams = readGenericParamList(
@@ -178,6 +180,8 @@ public struct Reader {
 
         let `protocol` = ProtocolDecl(context: context, name: name)
 
+        `protocol`.comment = protocolSyntax.leadingTrivia.description
+
         `protocol`.modifiers = readModifires(decls: protocolSyntax.modifiers)
 
         `protocol`.inheritedTypeReprs = readInheritedTypes(
@@ -196,6 +200,8 @@ public struct Reader {
         let name = classSyntax.name.text
 
         let `class` = ClassDecl(context: context, name: name)
+
+        `class`.comment = classSyntax.leadingTrivia.description
 
         `class`.modifiers = readModifires(decls: classSyntax.modifiers)
 

--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -129,6 +129,8 @@ public struct Reader {
 
         let `struct` = StructDecl(context: context, name: name)
 
+        `struct`.comment = structSyntax.leadingTrivia.description
+
         `struct`.modifiers = readModifires(decls: structSyntax.modifiers)
         
         `struct`.syntaxGenericParams = readGenericParamList(

--- a/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
@@ -1047,4 +1047,33 @@ enum E {
         let e = try XCTUnwrap(module.find(name: "E")?.asEnum)
         XCTAssertEqual(e.caseElements[safe: 0]?.name, "class")
     }
+
+    func testComment() throws {
+        let module = read("""
+import FoundationEssentials
+
+/// doc comment
+@MainActor
+class C {
+}
+// Which side does this comment attach
+// and multiline
+protocol P {
+}
+
+/* floating */
+
+private enum E {
+}
+""")
+
+        let c = try XCTUnwrap(module.find(name: "C")?.asClass)
+        XCTAssertEqual(c.comment, "\n\n/// doc comment\n")
+
+        let p = try XCTUnwrap(module.find(name: "P")?.asProtocol)
+        XCTAssertEqual(p.comment, "\n// Which side does this comment attach\n// and multiline\n")
+
+        let e = try XCTUnwrap(module.find(name: "E")?.asEnum)
+        XCTAssertEqual(e.comment, "\n\n/* floating */\n\n")
+    }
 }

--- a/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
@@ -36,6 +36,7 @@ struct S {
 
     func testSimpleStruct() throws {
         let module = read("""
+/// comment
 struct S {
     var a: Int?
 }
@@ -45,6 +46,7 @@ struct S {
         let s = try XCTUnwrap(module.find(name: "S")?.asStruct)
         XCTAssertEqual(s.name, "S")
 
+        XCTAssertEqual(s.comment, "/// comment\n")
         XCTAssertEqual(s.moduleContext.name, "main")
 
         let a = try XCTUnwrap(s.find(name: "a")?.asVar)

--- a/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
@@ -1064,6 +1064,8 @@ protocol P {
 /* floating */
 
 private enum E {
+    // nested
+    @available(*, unavailable) struct S {}
 }
 """)
 
@@ -1075,5 +1077,8 @@ private enum E {
 
         let e = try XCTUnwrap(module.find(name: "E")?.asEnum)
         XCTAssertEqual(e.comment, "\n\n/* floating */\n\n")
+
+        let s = try XCTUnwrap(e.find(name: "S")?.asStruct)
+        XCTAssertEqual(s.comment, "\n    // nested\n    ")
     }
 }


### PR DESCRIPTION
## やりたいこと

コード生成時に、対象の型に対して独自の命令をしたい需要があり、何らかの形で型にアノテーションする方法を考えています。
よくあるのはコメントで専用マーカーを付与する形であり、同じ形を踏襲したいと思ったので、まずは型宣言に付与されたコメントを読み取れるようにしたくなりました。


以下のようなコメントを足すイメージです。この例では、この型が独自のcoding関数を持っていてrawValueへ処理を転送することを明示しています。

```swift
/// @CallableKit(transferringRawValueType: true)
public struct GenericID<_IDSpecifier, RawValue: Sendable....
```

## 追加すること

NominalTypeに`comment`プロパティを付与して、型につけられたコメントを読み取れるようにします。
下層ライブラリではこの`comment`プロパティから正規表現で特定のパターンをくり抜いて独自の処理をしていく想定です。

なお、現時点の実装はレビュー用に`StructDecl`にのみ適用しています。方針良さそうであれば他のNominalTypeにも適用していくつもりです。