### PR TITLE
static helper

### DIFF
--- a/Sources/SwiftTypeReader/Decl/DeclModifier.swift
+++ b/Sources/SwiftTypeReader/Decl/DeclModifier.swift
@@ -13,4 +13,17 @@ public enum DeclModifier: String, Hashable {
     case `fileprivate`
     case `internal`
     case `open`
+
+    public var isStatic: Bool {
+        switch self {
+        case .`static`, .`class`: return true
+        default: return false
+        }
+    }
+}
+
+extension [DeclModifier] {
+    public var isStatic: Bool {
+        contains { $0.isStatic }
+    }
 }

--- a/Sources/SwiftTypeReader/Decl/VarDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/VarDecl.swift
@@ -45,3 +45,13 @@ public final class VarDecl: ValueDecl {
         }
     }
 }
+
+extension [VarDecl] {
+    public var instances: [VarDecl] {
+        filter { !$0.modifiers.isStatic }
+    }
+
+    public var statics: [VarDecl] {
+        filter { $0.modifiers.isStatic }
+    }
+}


### PR DESCRIPTION
```swift
struct.storedProperties.instances
```

のような形でインスタンスメンバを絞り込めるようにする。

そもそもstaticとinstanceが混ざっているのが変な気もしたが、
initializersはある意味instanceだけだし、typesなどはstaticだけだし、
membersプロパティがそもそも意味構造よりも構文的な観点で命名されている側面があるので、
下位互換を維持して余計なことをするのは避けた
