### PR TITLE
Add `Set` to StandardLibraryBuilder.swift

### DIFF
--- a/Sources/SwiftTypeReader/Decl/StandardLibraryBuilder.swift
+++ b/Sources/SwiftTypeReader/Decl/StandardLibraryBuilder.swift
@@ -67,6 +67,7 @@ struct StandardLibraryBuilder {
         addStruct(name: "String")
         addEnum(name: "Optional", genericParams: ["Wrapped"])
         addStruct(name: "Array", genericParams: ["Element"])
+        addStruct(name: "Set", genericParams: ["Element"])
         addStruct(name: "Dictionary", genericParams: ["Key", "Value"])
 
         addProtocol(name: "Encodable")


### PR DESCRIPTION
忘れられている`Set<Element>`をSwiftの型として追加します