### PR TITLE
Add attributes property to each decls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,5 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: swift-actions/setup-swift@v1
-        with:
-          swift-version: "5.7"
-      - uses: actions/checkout@v3
-      - run: swift package resolve
-      - run: swift build
+      - uses: actions/checkout@v4
       - run: swift test

--- a/Sources/SwiftTypeReader/Decl/AccessorDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/AccessorDecl.swift
@@ -17,16 +17,19 @@ public enum AccessorKind: String {
 public final class AccessorDecl: ValueDecl {
     public init(
         `var`: VarDecl,
+        attributes: [Attribute],
         modifiers: [DeclModifier],
         kind: AccessorKind
     ) {
         self.var = `var`
+        self.attributes = attributes
         self.modifiers = modifiers
         self.kind = kind
     }
 
     public unowned var `var`: VarDecl
     public var parentContext: (any DeclContext)? { `var`.parentContext }
+    public var attributes: [Attribute]
     public var modifiers: [DeclModifier]
     public var kind: AccessorKind
     public var valueName: String? { nil }

--- a/Sources/SwiftTypeReader/Decl/Attribute.swift
+++ b/Sources/SwiftTypeReader/Decl/Attribute.swift
@@ -1,0 +1,8 @@
+public struct Attribute: Hashable {
+    public init(name: String) {
+        self.name = name
+    }
+    
+    public var name: String
+    // arguments is not supported yet
+}

--- a/Sources/SwiftTypeReader/Decl/ClassDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/ClassDecl.swift
@@ -5,6 +5,7 @@ public final class ClassDecl: NominalTypeDecl {
     ) {
         self.context = context
         self.comment = ""
+        self.attributes = []
         self.modifiers = []
         self.name = name
         self.syntaxGenericParams = .init()
@@ -15,6 +16,7 @@ public final class ClassDecl: NominalTypeDecl {
     public unowned var context: any DeclContext
     public var parentContext: (any DeclContext)? { context }
     public var comment: String
+    public var attributes: [Attribute]
     public var modifiers: [DeclModifier]
     public var name: String
     public var syntaxGenericParams: GenericParamList

--- a/Sources/SwiftTypeReader/Decl/EnumDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/EnumDecl.swift
@@ -5,6 +5,7 @@ public final class EnumDecl: NominalTypeDecl {
     ) {
         self.context = context
         self.comment = ""
+        self.attributes = []
         self.modifiers = []
         self.name = name
         self.syntaxGenericParams = .init()
@@ -15,6 +16,7 @@ public final class EnumDecl: NominalTypeDecl {
     public unowned var context: any DeclContext
     public var parentContext: (any DeclContext)? { context }
     public var comment: String
+    public var attributes: [Attribute]
     public var modifiers: [DeclModifier]
     public var name: String
     public var syntaxGenericParams: GenericParamList

--- a/Sources/SwiftTypeReader/Decl/FuncDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/FuncDecl.swift
@@ -1,17 +1,18 @@
 public final class FuncDecl: ValueDecl & DeclContext {
     public init(
         context: any DeclContext,
-        modifiers: [DeclModifier],
         name: String
     ) {
         self.context = context
-        self.modifiers = modifiers
+        self.attributes = []
+        self.modifiers = []
         self.name = name
         self.parameters = []
     }
 
     public unowned var context: any DeclContext
     public var parentContext: (any DeclContext)? { context }
+    public var attributes: [Attribute]
     public var modifiers: [DeclModifier]
     public var name: String
     public var valueName: String? { name }

--- a/Sources/SwiftTypeReader/Decl/InitDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/InitDecl.swift
@@ -4,12 +4,14 @@ public final class InitDecl: ValueDecl & DeclContext {
         modifiers: [DeclModifier]
     ) {
         self.context = context
+        self.attributes = []
         self.modifiers = modifiers
         self.parameters = []
     }
 
     public unowned var context: any DeclContext
     public var parentContext: (any DeclContext)? { context }
+    public var attributes: [Attribute]
     public var modifiers: [DeclModifier]
     public var valueName: String? { nil }
 

--- a/Sources/SwiftTypeReader/Decl/ProtocolDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/ProtocolDecl.swift
@@ -5,6 +5,7 @@ public final class ProtocolDecl: NominalTypeDecl {
     ) {
         self.context = context
         self.comment = ""
+        self.attributes = []
         self.modifiers = []
         self.name = name
         self.inheritedTypeReprs = []
@@ -14,6 +15,7 @@ public final class ProtocolDecl: NominalTypeDecl {
     public unowned var context: any DeclContext
     public var parentContext: (any DeclContext)? { context }
     public var comment: String
+    public var attributes: [Attribute]
     public var modifiers: [DeclModifier]
     public var name: String
     public var syntaxGenericParams: GenericParamList { .init() }

--- a/Sources/SwiftTypeReader/Decl/StructDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/StructDecl.swift
@@ -5,6 +5,7 @@ public final class StructDecl: NominalTypeDecl {
     ) {
         self.context = context
         self.comment = ""
+        self.attributes = []
         self.modifiers = []
         self.name = name
         self.syntaxGenericParams = .init()
@@ -15,6 +16,7 @@ public final class StructDecl: NominalTypeDecl {
     public unowned var context: any DeclContext
     public var parentContext: (any DeclContext)? { context }
     public var comment: String
+    public var attributes: [Attribute]
     public var modifiers: [DeclModifier]
     public var name: String
     public var syntaxGenericParams: GenericParamList

--- a/Sources/SwiftTypeReader/Decl/TypeAliasDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/TypeAliasDecl.swift
@@ -5,6 +5,7 @@ public final class TypeAliasDecl: GenericTypeDecl {
         underlyingTypeRepr: any TypeRepr
     ) {
         self.context = context
+        self.attributes = []
         self.modifiers = []
         self.name = name
         self.syntaxGenericParams = .init()
@@ -13,6 +14,7 @@ public final class TypeAliasDecl: GenericTypeDecl {
 
     public unowned var context: any DeclContext
     public var parentContext: (any DeclContext)? { context }
+    public var attributes: [Attribute]
     public var modifiers: [DeclModifier]
     public var name: String
     public var valueName: String? { name }

--- a/Sources/SwiftTypeReader/Decl/VarDecl.swift
+++ b/Sources/SwiftTypeReader/Decl/VarDecl.swift
@@ -11,13 +11,13 @@ public enum PropertyKind: Hashable {
 public final class VarDecl: ValueDecl {
     public init(
         context: any DeclContext,
-        modifiers: [DeclModifier],
         kind: VarKind,
         name: String,
         typeRepr: any TypeRepr
     ) {
         self.context = context
-        self.modifiers = modifiers
+        self.attributes = []
+        self.modifiers = []
         self.kind = kind
         self.name = name
         self.typeRepr = typeRepr
@@ -26,6 +26,7 @@ public final class VarDecl: ValueDecl {
 
     public unowned var context: any DeclContext
     public var parentContext: (any DeclContext)? { context }
+    public var attributes: [Attribute]
     public var modifiers: [DeclModifier]
     public var kind: VarKind
     public var name: String

--- a/Sources/SwiftTypeReader/Reader/AttributeReader.swift
+++ b/Sources/SwiftTypeReader/Reader/AttributeReader.swift
@@ -1,0 +1,17 @@
+import SwiftSyntax
+
+struct AttributeReader {
+    var attributes: [Attribute] = []
+
+    mutating func read(list: AttributeListSyntax) {
+        for element in list {
+            guard case .attribute(let attributeSyntax) = element else {
+                continue
+            }
+
+            attributes.append(.init(
+                name: attributeSyntax.attributeName.trimmedDescription
+            ))
+        }
+    }
+}

--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -398,11 +398,11 @@ public struct Reader {
 
         let `var` = VarDecl(
             context: context,
-            modifiers: modifiers.modifiers,
             kind: kind,
             name: name,
             typeRepr: typeRepr
         )
+        `var`.modifiers = modifiers.modifiers
 
         if let accessor = binding.accessorBlock {
             `var`.accessors += readVarAccessor(accessor: accessor.accessors, on: `var`)
@@ -460,9 +460,10 @@ public struct Reader {
 
         let `func` = FuncDecl(
             context: context,
-            modifiers: modifiers.modifiers,
             name: name
         )
+
+        `func`.modifiers = modifiers.modifiers
 
         `func`.parameters = functionSyntax.signature.parameterClause.parameters.compactMap { (param) in
             readParam(param: param, on: `func`)

--- a/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
@@ -1081,4 +1081,31 @@ private enum E {
         let s = try XCTUnwrap(e.find(name: "S")?.asStruct)
         XCTAssertEqual(s.comment, "\n    // nested\n    ")
     }
+
+    func testAttributes() throws {
+        let module = read("""
+@MainActor
+struct S {
+}
+
+@available(*, unavailable) 
+// comment
+enum E {
+    case `class`
+}
+
+@MyMacro
+public protocol P {
+}
+""")
+
+        let s = try XCTUnwrap(module.find(name: "S")?.asStruct)
+        XCTAssertEqual(s.attributes.map(\.name), ["MainActor"])
+
+        let e = try XCTUnwrap(module.find(name: "E")?.asEnum)
+        XCTAssertEqual(e.attributes.map(\.name), ["available"])
+
+        let p = try XCTUnwrap(module.find(name: "P")?.asProtocol)
+        XCTAssertEqual(p.attributes.map(\.name), ["MyMacro"])
+    }
 }

--- a/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
@@ -1124,9 +1124,9 @@ public protocol P {
         XCTAssertEqual(p.attributes.map(\.name), ["MyMacro", "MainActor"])
 
         let c = try XCTUnwrap(module.find(name: "C")?.asClass)
-        XCTAssertEqual(p.attributes.map(\.name), ["objc"])
+        XCTAssertEqual(c.attributes.map(\.name), ["objc"])
 
-        let cInit = try XCTUnwrap(c.find(name: "init")?.asInit)
+        let cInit = try XCTUnwrap(c.initializers.first)
         XCTAssertEqual(cInit.attributes.map(\.name), ["objc"])
 
         let cFoo = try XCTUnwrap(c.find(name: "foo2")?.asFunc)


### PR DESCRIPTION
`@MainActor`などの各種attributeをこれまで読めなかったようなので、読めるようにします。

Attributeは`()`の中身のパターンが多く複雑であるため、一旦は`name`プロパティのみを持つこととします。
需要が生まれ次第、中身のパースも行うという想定です。