### PR TITLE
SwiftIfConfigを利用して#ifを評価する

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,33 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "codegenkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/omochi/CodegenKit.git",
-      "state" : {
-        "revision" : "ab5ad508aab30b1572caa6e73ac0206611db0b0d",
-        "version" : "2.0.0"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "011f0c765fb46d9cac61bca19be0527e99c98c8b",
-        "version" : "1.5.1"
-      }
-    },
-    {
-      "identity" : "swift-cmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-cmark.git",
-      "state" : {
-        "revision" : "b022b08312decdc46585e0b3440d97f6f22ef703",
-        "version" : "0.6.0"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -37,30 +10,12 @@
       }
     },
     {
-      "identity" : "swift-format",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-format.git",
-      "state" : {
-        "revision" : "ffbb3225ffda37b62c7283c70e87e8bc7e8e202a",
-        "version" : "601.0.0"
-      }
-    },
-    {
-      "identity" : "swift-markdown",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-markdown.git",
-      "state" : {
-        "revision" : "ea79e83c8744d2b50b0dc2d5bbd1e857e1253bf9",
-        "version" : "0.6.0"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
-        "version" : "601.0.1"
+        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
+        "version" : "603.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -12,28 +12,28 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", "601.0.1"..<"999.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", "603.0.1"..<"999.0.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.3"),
-        .package(url: "https://github.com/omochi/CodegenKit.git", from: "2.0.0"),
+//        .package(url: "https://github.com/omochi/CodegenKit.git", from: "2.0.0"),
 //        .package(path: "../CodegenKit")
     ],
     targets: [
-        .executableTarget(
-            name: "codegen",
-            dependencies: [
-                .product(name: "CodegenKit", package: "CodegenKit")
-            ]
-        ),
-        .plugin(
-            name: "CodegenPlugin",
-            capability: .command(
-                intent: .custom(verb: "codegen", description: "codegen"),
-                permissions: [.writeToPackageDirectory(reason: "codegen")]
-            ),
-            dependencies: [
-                .target(name: "codegen")
-            ]
-        ),
+//        .executableTarget(
+//            name: "codegen",
+//            dependencies: [
+//                .product(name: "CodegenKit", package: "CodegenKit")
+//            ]
+//        ),
+//        .plugin(
+//            name: "CodegenPlugin",
+//            capability: .command(
+//                intent: .custom(verb: "codegen", description: "codegen"),
+//                permissions: [.writeToPackageDirectory(reason: "codegen")]
+//            ),
+//            dependencies: [
+//                .target(name: "codegen")
+//            ]
+//        ),
         .target(
             name: "SwiftTypeReader",
             dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,7 @@ let package = Package(
             name: "SwiftTypeReader",
             dependencies: [
                 .product(name: "SwiftParser", package: "swift-syntax"),
+                .product(name: "SwiftIfConfig", package: "swift-syntax"),
                 .product(name: "Collections", package: "swift-collections"),
             ]
         ),

--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftSyntax
 import SwiftParser
+import SwiftIfConfig
 
 public struct Reader {
     public var context: Context
@@ -8,25 +9,30 @@ public struct Reader {
     public var fileManager: FileManager
 #endif
     public var module: Module
+    public var buildConfiguration: (any BuildConfiguration)?
 
 #if !os(WASI)
     public init(
         context: Context,
         fileManager: FileManager = .default,
-        module: Module? = nil
+        module: Module? = nil,
+        buildConfiguration: (any BuildConfiguration)? = nil
     ) {
         self.context = context
         self.fileManager = fileManager
         self.module = module ?? context.getOrCreateModule(name: "main")
+        self.buildConfiguration = buildConfiguration
     }
 
 #else
     public init(
         context: Context,
-        module: Module? = nil
+        module: Module? = nil,
+        buildConfiguration: (any BuildConfiguration)?
     ) {
         self.context = context
         self.module = module ?? context.getOrCreateModule(name: "main")
+        self.buildConfiguration = buildConfiguration
     }
 #endif
 
@@ -51,7 +57,7 @@ public struct Reader {
 #endif
 
     public func read(source: String, file: URL) -> SourceFile {
-        return Reader.read(source: source, file: file, on: module)
+        return Reader.read(source: source, file: file, on: module, buildConfiguration: buildConfiguration)
     }
 
     static func unescapeIdentifier(_ str: String) -> String {
@@ -60,24 +66,34 @@ public struct Reader {
 
     static func read(
         source sourceString: String, file: URL,
-        on module: Module
+        on module: Module,
+        buildConfiguration: (any BuildConfiguration)?
     ) -> SourceFile {
         let sourceSyntax: SourceFileSyntax = Parser.parse(source: sourceString)
         let source = SourceFile(module: module, file: file)
-        ReaderVisitor(source: source).walk(sourceSyntax)
+        let configuration: any BuildConfiguration = buildConfiguration ?? StaticBuildConfiguration(
+            languageVersion: VersionTuple(components: [6, 0]),
+            compilerVersion: VersionTuple(components: [6, 0])
+        )
+        ReaderVisitor(
+            source: source,
+            configuration: configuration
+        ).walk(sourceSyntax)
         module.sources.append(source)
 
         return source
     }
 
-    private final class ReaderVisitor: SyntaxVisitor {
+    private final class ReaderVisitor: ActiveSyntaxVisitor {
         let source: SourceFile
         var contextStack: [any DeclContext]
-
-        init(source: SourceFile) {
+        init(
+            source: SourceFile,
+            configuration: some BuildConfiguration
+        ) {
             self.source = source
             self.contextStack = [source]
-            super.init(viewMode: .sourceAccurate)
+            super.init(viewMode: .sourceAccurate, configuration: configuration)
         }
 
         var currentContext: any DeclContext {

--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -19,6 +19,7 @@ public struct Reader {
         self.fileManager = fileManager
         self.module = module ?? context.getOrCreateModule(name: "main")
     }
+
 #else
     public init(
         context: Context,
@@ -62,69 +63,122 @@ public struct Reader {
         on module: Module
     ) -> SourceFile {
         let sourceSyntax: SourceFileSyntax = Parser.parse(source: sourceString)
-
-        let statements = sourceSyntax.statements.map { $0.item }
-
         let source = SourceFile(module: module, file: file)
-
-        for decl in statements.compactMap({ $0.as(DeclSyntax.self) }) {
-            if let type = readNominalType(decl: decl, on: source) {
-                source.types.append(type)
-            } else if let type = readTypeAlias(decl: decl, on: source) {
-                source.types.append(type)
-            } else if let `import` = readImport(decl: decl, on: source) {
-                source.imports.append(`import`)
-            } else if let `func` = readFunc(decl: decl, on: source) {
-                source.funcs.append(`func`)
-            }
-        }
-
+        ReaderVisitor(source: source).walk(sourceSyntax)
         module.sources.append(source)
 
         return source
     }
 
-    static func readMembers(block: MemberBlockSyntax, on context: some DeclContext) -> [any ValueDecl] {
-        return block.members.flatMap {
-            readMember(decl: $0.decl, on: context)
+    private final class ReaderVisitor: SyntaxVisitor {
+        let source: SourceFile
+        var contextStack: [any DeclContext]
+
+        init(source: SourceFile) {
+            self.source = source
+            self.contextStack = [source]
+            super.init(viewMode: .sourceAccurate)
+        }
+
+        var currentContext: any DeclContext {
+            contextStack.last!
+        }
+
+        override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+            let decl = Reader.readStruct(struct: node, on: currentContext)
+            currentContext.append(decl: decl)
+            contextStack.append(decl)
+            return .visitChildren
+        }
+
+        override func visitPost(_ node: StructDeclSyntax) {
+            contextStack.removeLast()
+        }
+
+        override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+            let decl = Reader.readEnum(enum: node, on: currentContext)
+            currentContext.append(decl: decl)
+            contextStack.append(decl)
+            return .visitChildren
+        }
+
+        override func visitPost(_ node: EnumDeclSyntax) {
+            contextStack.removeLast()
+        }
+
+        override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+            let decl = Reader.readProtocol(protocol: node, on: currentContext)
+            currentContext.append(decl: decl)
+            contextStack.append(decl)
+            return .visitChildren
+        }
+
+        override func visitPost(_ node: ProtocolDeclSyntax) {
+            contextStack.removeLast()
+        }
+
+        override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+            let decl = Reader.readClass(class: node, on: currentContext)
+            currentContext.append(decl: decl)
+            contextStack.append(decl)
+            return .visitChildren
+        }
+
+        override func visitPost(_ node: ClassDeclSyntax) {
+            contextStack.removeLast()
+        }
+
+        override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
+            guard let decl = Reader.readTypeAlias(typeAlias: node, on: currentContext) else {
+                return .skipChildren
+            }
+            currentContext.append(decl: decl)
+            return .skipChildren
+        }
+
+        override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+            Reader.readVars(var: node, on: currentContext).forEach {
+                currentContext.append(decl: $0)
+            }
+            return .skipChildren
+        }
+
+        override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+            let decl = Reader.readFunc(function: node, on: currentContext)
+            currentContext.append(decl: decl)
+            return .skipChildren
+        }
+
+        override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+            let decl = Reader.readInit(initializer: node, on: currentContext)
+            currentContext.append(decl: decl)
+            return .skipChildren
+        }
+
+        override func visit(_ node: EnumCaseDeclSyntax) -> SyntaxVisitorContinueKind {
+            Reader.readCaseElements(enumCase: node, on: currentContext).forEach {
+                currentContext.append(decl: $0)
+            }
+            return .skipChildren
+        }
+
+        override func visit(_ node: AssociatedTypeDeclSyntax) -> SyntaxVisitorContinueKind {
+            guard let decl = Reader.readAssociatedType(associatedType: node, on: currentContext) else {
+                return .skipChildren
+            }
+            currentContext.append(decl: decl)
+            return .skipChildren
+        }
+
+        override func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
+            if let decl = Reader.readImport(import: node, on: source) {
+                source.imports.append(decl)
+            }
+            return .skipChildren
         }
     }
 
-    static func readMember(decl: DeclSyntax, on context: some DeclContext) -> [any ValueDecl] {
-        if let type = readNominalType(decl: decl, on: context) {
-            return [type]
-        } else if let type = readTypeAlias(decl: decl, on: context) {
-            return [type]
-        } else if let vars = readVars(decl: decl, on: context) {
-            return vars
-        } else if let `func` = readFunc(decl: decl, on: context) {
-            return [`func`]
-        } else if let `init` = readInit(decl: decl, on: context) {
-            return [`init`]
-        } else if let cases = readCaseElements(decl: decl, on: context) {
-            return cases
-        } else if let associatedType = readAssociatedType(decl: decl, on: context) {
-            return [associatedType]
-        } else {
-            return []
-        }
-    }
-
-    static func readNominalType(decl: DeclSyntax, on context: some DeclContext) -> (any NominalTypeDecl)? {
-        if let decl = decl.as(StructDeclSyntax.self) {
-            return readStruct(struct: decl, on: context)
-        } else if let decl = decl.as(EnumDeclSyntax.self) {
-            return readEnum(enum: decl, on: context)
-        } else if let decl = decl.as(ProtocolDeclSyntax.self) {
-            return readProtocol(protocol: decl, on: context)
-        } else if let decl = decl.as(ClassDeclSyntax.self) {
-            return readClass(class: decl, on: context)
-        } else {
-            return nil
-        }
-    }
-
-    static func readStruct(struct structSyntax: StructDeclSyntax, on context: some DeclContext) -> StructDecl? {
+    static func readStruct(struct structSyntax: StructDeclSyntax, on context: some DeclContext) -> StructDecl {
         let name = structSyntax.name.text
 
         let `struct` = StructDecl(context: context, name: name)
@@ -142,14 +196,10 @@ public struct Reader {
             inheritance: structSyntax.inheritanceClause
         )
 
-        `struct`.members = readMembers(
-            block: structSyntax.memberBlock, on: `struct`
-        )
-
         return `struct`
     }
 
-    static func readEnum(enum enumSyntax: EnumDeclSyntax, on context: some DeclContext) -> EnumDecl? {
+    static func readEnum(enum enumSyntax: EnumDeclSyntax, on context: some DeclContext) -> EnumDecl {
         let name = enumSyntax.name.text
 
         let `enum` = EnumDecl(context: context, name: name)
@@ -167,17 +217,13 @@ public struct Reader {
             inheritance: enumSyntax.inheritanceClause
         )
 
-        `enum`.members = readMembers(
-            block: enumSyntax.memberBlock, on: `enum`
-        )
-
         return `enum`
     }
 
     static func readProtocol(
         `protocol` protocolSyntax: ProtocolDeclSyntax,
         on context: some DeclContext
-    ) -> ProtocolDecl? {
+    ) -> ProtocolDecl {
         let name = protocolSyntax.name.text
 
         let `protocol` = ProtocolDecl(context: context, name: name)
@@ -191,15 +237,13 @@ public struct Reader {
             inheritance: protocolSyntax.inheritanceClause
         )
 
-        `protocol`.members = readMembers(block: protocolSyntax.memberBlock, on: `protocol`)
-
         return `protocol`
     }
 
     static func readClass(
         class classSyntax: ClassDeclSyntax,
         on context: some DeclContext
-    ) -> ClassDecl? {
+    ) -> ClassDecl {
         let name = classSyntax.name.text
 
         let `class` = ClassDecl(context: context, name: name)
@@ -217,21 +261,16 @@ public struct Reader {
             inheritance: classSyntax.inheritanceClause
         )
 
-        `class`.members = readMembers(
-            block: classSyntax.memberBlock, on: `class`
-        )
-
         return `class`
     }
 
     static func readCaseElements(
-        decl: DeclSyntax,
+        enumCase caseSyntax: EnumCaseDeclSyntax,
         on context: some DeclContext
-    ) -> [EnumCaseElementDecl]? {
-        guard let caseDecl = decl.as(EnumCaseDeclSyntax.self),
-              let `enum` = context.asEnum else { return nil }
+    ) -> [EnumCaseElementDecl] {
+        guard let `enum` = context.asEnum else { return [] }
 
-        return caseDecl.elements.map { (element) in
+        return caseSyntax.elements.map { (element) in
             readCaseElement(element: element, on: `enum`)
         }
     }
@@ -266,18 +305,10 @@ public struct Reader {
     }
 
     static func readAssociatedType(
-        decl: DeclSyntax,
+        associatedType associatedTypeSyntax: AssociatedTypeDeclSyntax,
         on context: some DeclContext
     ) -> AssociatedTypeDecl? {
-        guard let decl = decl.as(AssociatedTypeDeclSyntax.self),
-              let `protocol` = context.asProtocol else { return nil }
-        return readAssociatedType(associatedType: decl, on: `protocol`)
-    }
-
-    static func readAssociatedType(
-        associatedType associatedTypeSyntax: AssociatedTypeDeclSyntax,
-        on `protocol`: ProtocolDecl
-    ) -> AssociatedTypeDecl {
+        guard let `protocol` = context.asProtocol else { return nil }
         let name = associatedTypeSyntax.name.text
 
         let associatedType = AssociatedTypeDecl(protocol: `protocol`, name: name)
@@ -358,11 +389,6 @@ public struct Reader {
             syntaxName: name,
             typeRepr: typeRepr
         )
-    }
-
-    static func readVars(decl: DeclSyntax, on context: some DeclContext) -> [VarDecl]? {
-        guard let decl = decl.as(VariableDeclSyntax.self) else { return nil }
-        return readVars(var: decl, on: context)
     }
 
     static func readVars(
@@ -447,11 +473,6 @@ public struct Reader {
         return AccessorDecl(var: `var`, attributes: attributes.attributes, modifiers: modifiers.modifiers, kind: kind)
     }
 
-    static func readFunc(decl: DeclSyntax, on context: some DeclContext) -> FuncDecl? {
-        guard let decl = decl.as(FunctionDeclSyntax.self) else { return nil }
-        return readFunc(function: decl, on: context)
-    }
-
     static func readFunc(
         function functionSyntax: FunctionDeclSyntax,
         on context: some DeclContext
@@ -480,11 +501,6 @@ public struct Reader {
         }
 
         return `func`
-    }
-
-    static func readInit(decl: DeclSyntax, on context: some DeclContext) -> InitDecl? {
-        guard let decl = decl.as(InitializerDeclSyntax.self) else { return nil }
-        return readInit(initializer: decl, on: context)
     }
 
     static func readInit(
@@ -588,12 +604,10 @@ public struct Reader {
         }
     }
 
-    static func readTypeAlias(decl: DeclSyntax, on context: some DeclContext) -> TypeAliasDecl? {
-        guard let decl = decl.as(TypeAliasDeclSyntax.self) else { return nil }
+    static func readTypeAlias(typeAlias typeAliasSyntax: TypeAliasDeclSyntax, on context: some DeclContext) -> TypeAliasDecl? {
+        let name = typeAliasSyntax.name.text
 
-        let name = decl.name.text
-
-        let underlyingSyntax = decl.initializer
+        let underlyingSyntax = typeAliasSyntax.initializer
 
         guard let underlying = TypeReprReader.read(type: underlyingSyntax.value) else { return nil }
 
@@ -603,28 +617,22 @@ public struct Reader {
             underlyingTypeRepr: underlying
         )
 
-        alias.modifiers = readModifires(decls: decl.modifiers)
+        alias.attributes = readAttributes(list: typeAliasSyntax.attributes)
+        alias.modifiers = readModifires(decls: typeAliasSyntax.modifiers)
 
-        alias.syntaxGenericParams = readGenericParamList(clause: decl.genericParameterClause, on: alias)
+        alias.syntaxGenericParams = readGenericParamList(clause: typeAliasSyntax.genericParameterClause, on: alias)
 
         return alias
-    }
-
-    static func readImport(decl: DeclSyntax, on source: SourceFile) -> ImportDecl? {
-        if let decl = decl.as(ImportDeclSyntax.self) {
-            return readImport(import: decl, on: source)
-        } else {
-            return nil
-        }
     }
 
     static func readImport(
         `import` importSyntax: ImportDeclSyntax,
         on source: SourceFile
-    ) -> ImportDecl {
+    ) -> ImportDecl? {
         let isScoped = importSyntax.importKindSpecifier != nil
 
         let path = importSyntax.path.map { $0.name.text }
+        guard !path.isEmpty else { return nil }
 
         let moduleName: String
         let declName: String?
@@ -644,3 +652,22 @@ public struct Reader {
     }
 }
 
+extension DeclContext {
+    fileprivate func append(decl: any ValueDecl) {
+        if let source = self.asSourceFile {
+            if let type = decl.asGenericType {
+                source.types.append(type)
+            } else if let `func` = decl.asFunc {
+                source.funcs.append(`func`)
+            }
+        } else if let `struct` = self.asStruct {
+            `struct`.members.append(decl)
+        } else if let `enum` = self.asEnum {
+            `enum`.members.append(decl)
+        } else if let `protocol` = self.asProtocol {
+            `protocol`.members.append(decl)
+        } else if let `class` = self.asClass {
+            `class`.members.append(decl)
+        }
+    }
+}

--- a/Sources/SwiftTypeReader/RequestEvaluator/CycleRequestError.swift
+++ b/Sources/SwiftTypeReader/RequestEvaluator/CycleRequestError.swift
@@ -1,11 +1,7 @@
 public struct CycleRequestError: Error & CustomStringConvertible {
-    public var request: any Request
-
     public init(request: any Request) {
-        self.request = request
+        self.description = "request cycle detected: \(request)"
     }
 
-    public var description: String {
-        return "request cycle detected: \(request)"
-    }
+    public var description: String
 }

--- a/Tests/SwiftTypeReaderTests/IfConfigTests.swift
+++ b/Tests/SwiftTypeReaderTests/IfConfigTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+import SwiftTypeReader
+import SwiftIfConfig
+
+final class IfConfigTests: ReaderTestCaseBase {
+    func testNoBuildConfiguration() throws {
+        let reader = Reader(
+            context: context,
+            buildConfiguration: nil
+        )
+        _ = reader.read(
+            source: """
+            #if os(Linux)
+            struct LinuxOnly {}
+            #else
+            struct OtherOnly {}
+            #endif
+            """,
+            file: URL(fileURLWithPath: "main.swift")
+        )
+
+        XCTAssertNil(reader.module.find(name: "LinuxOnly"))
+        XCTAssertNotNil(reader.module.find(name: "OtherOnly")?.asStruct)
+    }
+
+    func testBuildConfigurationCustomCondition() throws {
+        let reader = Reader(
+            context: context,
+            buildConfiguration: StaticBuildConfiguration(
+                customConditions: ["DEBUG"],
+                languageVersion: VersionTuple(components: [6, 0]),
+                compilerVersion: VersionTuple(components: [6, 0])
+            )
+        )
+        _ = reader.read(
+            source: """
+            #if DEBUG
+            struct DebugOnly {}
+            #else
+            struct ReleaseOnly {}
+            #endif
+            """,
+            file: URL(fileURLWithPath: "main.swift")
+        )
+
+        XCTAssertNotNil(reader.module.find(name: "DebugOnly")?.asStruct)
+        XCTAssertNil(reader.module.find(name: "ReleaseOnly"))
+    }
+
+    func testBuildConfigurationTargetOS() throws {
+        let reader = Reader(
+            context: context,
+            buildConfiguration: StaticBuildConfiguration(
+                targetOSs: ["macOS"],
+                languageVersion: VersionTuple(components: [6, 0]),
+                compilerVersion: VersionTuple(components: [6, 0])
+            )
+        )
+        _ = reader.read(
+            source: """
+            #if os(macOS)
+            struct MacOnly {}
+            #elseif os(Linux)
+            struct LinuxOnly {}
+            #else
+            struct Fallback {}
+            #endif
+            """,
+            file: URL(fileURLWithPath: "main.swift")
+        )
+
+        XCTAssertNotNil(reader.module.find(name: "MacOnly")?.asStruct)
+        XCTAssertNil(reader.module.find(name: "LinuxOnly"))
+        XCTAssertNil(reader.module.find(name: "Fallback"))
+    }
+
+}


### PR DESCRIPTION
## 目的

現在、SwiftTypeReaderは`#if`を評価できず、IfConfigDeclの中にある全ての要素を破棄しています。
最近は[SwiftIfConfig](https://swiftpackageindex.com/swiftlang/swift-syntax/603.0.1/documentation/swiftifconfig/swiftifconfig)が追加されたので、これを用いて`#if`の中を評価し、マルチプラットフォームな開発に耐えられるような設計にしたいです。

`Reader`の処理を改善し、`BuildConfiguration`をオプション引数として取れるようにします。

## 修正内容

まず、Readerの処理をSyntaxVisitorを使った実装に書き換えています。
手で行っていた読み取りループをSyntaxVisitorの形に合わせます。

その後、単にSyntaxVisitorをActiveSyntaxVisitorに置き換えることで、IfConfigに対応します。

## その他

CodegenKitはメンテナンスが滞っており、直接的に依存していない上に依存していると問題が起きるため、一旦削除しました。
いわゆるdevDependencies的なものであるため、package traitを使うと開発時だけ依存できて便利かもしれません。このPRのスコープ外なのでとりあえずコメントアウトするに留めています。