### PR TITLE
Skip reading extension block

### DIFF
--- a/Sources/SwiftTypeReader/Reader/Reader.swift
+++ b/Sources/SwiftTypeReader/Reader/Reader.swift
@@ -192,6 +192,11 @@ public struct Reader {
             }
             return .skipChildren
         }
+
+        override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+            // extension is not yet supported
+            return .skipChildren
+        }
     }
 
     static func readStruct(struct structSyntax: StructDeclSyntax, on context: some DeclContext) -> StructDecl {

--- a/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
+++ b/Tests/SwiftTypeReaderTests/BasicReaderTests.swift
@@ -1135,4 +1135,19 @@ public protocol P {
         let cValue = try XCTUnwrap(c.find(name: "value")?.asVar)
         XCTAssertEqual(cValue.attributes.map(\.name), ["Invalidating"])
     }
+
+    func testIgnoreExtension() throws {
+        let module = read("""
+struct S {
+}
+
+extension S {
+    typealias Foo = String
+}
+""")
+
+        let s = try XCTUnwrap(module.find(name: "S")?.asStruct)
+        XCTAssertNil(s.find(name: "Foo"))
+        XCTAssertNil(module.find(name: "Foo"))
+    }
 }


### PR DESCRIPTION
- https://github.com/omochi/SwiftTypeReader/pull/60 で起こしたデグレを修正します。

#60 以前の実装では、`extension`を読む実装はなく完全に無視されていました。
しかしSyntaxVisitorに移行したことで、暗黙的に`extension`の中をスキャンしていました。

理想的には`extension`にも対応したほうがよいのでしょうが、さらなるエッジケースを踏んで難しくなる可能性が高いです。
それは今後の課題として今回は元の挙動に合わせ、`extension`を明示的に無視します。