### PR TITLE
CodegenKitをアップデートする

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,24 @@
 {
+  "originHash" : "111b50a06af21281b2c34d7246bb7dc3d8e90764751c80a6a086f1703913dd3c",
   "pins" : [
+    {
+      "identity" : "codegenkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/omochi/CodegenKit.git",
+      "state" : {
+        "revision" : "180de40437117d4faba3efe48188ea5c29ab9892",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    },
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
@@ -19,5 +38,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "111b50a06af21281b2c34d7246bb7dc3d8e90764751c80a6a086f1703913dd3c",
+  "originHash" : "22fd52a2c30e65376b609473a09ab67e89ebf4e2a0116a6f2ba397eadafa5828",
   "pins" : [
     {
       "identity" : "codegenkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/omochi/CodegenKit.git",
       "state" : {
-        "revision" : "180de40437117d4faba3efe48188ea5c29ab9892",
-        "version" : "2.1.0"
+        "revision" : "75e9de2abe0d9ea1d821fdd008aba50ce339716e",
+        "version" : "2.1.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "603.0.1"..<"999.0.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.3"),
-        .package(url: "https://github.com/omochi/CodegenKit.git", from: "2.1.0"),
+        .package(url: "https://github.com/omochi/CodegenKit.git", from: "2.1.1"),
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 6.1
 
 import PackageDescription
 
@@ -14,26 +14,25 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "603.0.1"..<"999.0.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.3"),
-//        .package(url: "https://github.com/omochi/CodegenKit.git", from: "2.0.0"),
-//        .package(path: "../CodegenKit")
+        .package(url: "https://github.com/omochi/CodegenKit.git", from: "2.1.0"),
     ],
     targets: [
-//        .executableTarget(
-//            name: "codegen",
-//            dependencies: [
-//                .product(name: "CodegenKit", package: "CodegenKit")
-//            ]
-//        ),
-//        .plugin(
-//            name: "CodegenPlugin",
-//            capability: .command(
-//                intent: .custom(verb: "codegen", description: "codegen"),
-//                permissions: [.writeToPackageDirectory(reason: "codegen")]
-//            ),
-//            dependencies: [
-//                .target(name: "codegen")
-//            ]
-//        ),
+        .executableTarget(
+            name: "codegen",
+            dependencies: [
+                .product(name: "CodegenKit", package: "CodegenKit")
+            ]
+        ),
+        .plugin(
+            name: "CodegenPlugin",
+            capability: .command(
+                intent: .custom(verb: "codegen", description: "codegen"),
+                permissions: [.writeToPackageDirectory(reason: "codegen")]
+            ),
+            dependencies: [
+                .target(name: "codegen")
+            ]
+        ),
         .target(
             name: "SwiftTypeReader",
             dependencies: [

--- a/Plugins/CodegenPlugin/CodegenPlugin.swift
+++ b/Plugins/CodegenPlugin/CodegenPlugin.swift
@@ -6,11 +6,11 @@ struct CodegenPlugin: CommandPlugin {
     func performCommand(context: PluginContext, arguments: [String]) async throws {
         let codegen = try context.tool(named: "codegen")
 
-        let sourcesDir = context.package.directory.appending(subpath: "Sources")
+        let sourcesDir = context.package.directoryURL.appending(path: "Sources")
 
         let process = EasyProcess(
-            path: URL(fileURLWithPath: codegen.path.string),
-            args: [sourcesDir.string]
+            path: codegen.url,
+            args: [sourcesDir.description]
         )
         try process.run()
     }

--- a/Plugins/CodegenPlugin/CodegenPlugin.swift
+++ b/Plugins/CodegenPlugin/CodegenPlugin.swift
@@ -10,7 +10,7 @@ struct CodegenPlugin: CommandPlugin {
 
         let process = EasyProcess(
             path: codegen.url,
-            args: [sourcesDir.description]
+            args: [sourcesDir.path(percentEncoded: false)]
         )
         try process.run()
     }

--- a/Plugins/CodegenPlugin/EasyProcess.swift
+++ b/Plugins/CodegenPlugin/EasyProcess.swift
@@ -4,8 +4,8 @@ struct EasyProcess {
     init(
         path: URL,
         args: [String],
-        outSink: ((Data) -> Void)? = nil,
-        errorSink: ((Data) -> Void)? = nil
+        outSink: (@Sendable (Data) -> Void)? = nil,
+        errorSink: (@Sendable (Data) -> Void)? = nil
     ) {
         self.path = path
         self.args = args
@@ -15,20 +15,20 @@ struct EasyProcess {
 
     var path: URL
     var args: [String]
-    var outSink: (Data) -> Void
-    var errorSink: (Data) -> Void
+    var outSink: @Sendable (Data) -> Void
+    var errorSink: @Sendable (Data) -> Void
 
-    static func makeFileHandleSink(fileHandle: FileHandle) -> (Data) -> Void {
+    static func makeFileHandleSink(fileHandle: FileHandle) -> @Sendable (Data) -> Void {
         return { (data) in
             try? fileHandle.write(contentsOf: data)
         }
     }
 
-    static var defaultOutSink: (Data) -> Void {
+    static var defaultOutSink: @Sendable (Data) -> Void {
         makeFileHandleSink(fileHandle: .standardOutput)
     }
 
-    static var defaultErrorSink: (Data) -> Void {
+    static var defaultErrorSink: @Sendable (Data) -> Void {
         makeFileHandleSink(fileHandle: .standardError)
     }
 
@@ -43,7 +43,7 @@ struct EasyProcess {
         let outPipe = Pipe()
         p.standardOutput = outPipe
 
-        outPipe.fileHandleForReading.readabilityHandler = { (h) in
+        outPipe.fileHandleForReading.readabilityHandler = { [outSink] (h) in
             queue.sync {
                 let data = h.availableData
                 if !data.isEmpty {
@@ -55,7 +55,7 @@ struct EasyProcess {
         let errPipe = Pipe()
         p.standardError = errPipe
 
-        errPipe.fileHandleForReading.readabilityHandler = { (h) in
+        errPipe.fileHandleForReading.readabilityHandler = { [errorSink] (h) in
             queue.sync {
                 let data = h.availableData
                 if !data.isEmpty {

--- a/Sources/SwiftTypeReader/Decl/Decl.swift
+++ b/Sources/SwiftTypeReader/Decl/Decl.swift
@@ -5,27 +5,69 @@ public protocol Decl: AnyObject & HashableFromIdentity & _DeclParentContextHolde
 
 extension Decl {
     // @codegen(as) MARK: - cast
-    public var asAccessor: AccessorDecl? { self as? AccessorDecl }
-    public var asAssociatedType: AssociatedTypeDecl? { self as? AssociatedTypeDecl }
-    public var asClass: ClassDecl? { self as? ClassDecl }
-    public var asEnumCaseElement: EnumCaseElementDecl? { self as? EnumCaseElementDecl }
-    public var asEnum: EnumDecl? { self as? EnumDecl }
-    public var asFunc: FuncDecl? { self as? FuncDecl }
-    public var asGenericParam: GenericParamDecl? { self as? GenericParamDecl }
-    public var asGenericType: (any GenericTypeDecl)? { self as? any GenericTypeDecl }
-    public var asImport: ImportDecl? { self as? ImportDecl }
-    public var asInit: InitDecl? { self as? InitDecl }
-    public var asModule: Module? { self as? Module }
-    public var asNominalType: (any NominalTypeDecl)? { self as? any NominalTypeDecl }
-    public var asCaseParam: CaseParamDecl? { self as? CaseParamDecl }
-    public var asFuncParam: FuncParamDecl? { self as? FuncParamDecl }
-    public var asProtocol: ProtocolDecl? { self as? ProtocolDecl }
-    public var asSourceFile: SourceFile? { self as? SourceFile }
-    public var asStruct: StructDecl? { self as? StructDecl }
-    public var asTypeAlias: TypeAliasDecl? { self as? TypeAliasDecl }
-    public var asType: (any TypeDecl)? { self as? any TypeDecl }
-    public var asValue: (any ValueDecl)? { self as? any ValueDecl }
-    public var asVar: VarDecl? { self as? VarDecl }
+    public var asAccessor: AccessorDecl? {
+        self as? AccessorDecl
+    }
+    public var asAssociatedType: AssociatedTypeDecl? {
+        self as? AssociatedTypeDecl
+    }
+    public var asClass: ClassDecl? {
+        self as? ClassDecl
+    }
+    public var asEnumCaseElement: EnumCaseElementDecl? {
+        self as? EnumCaseElementDecl
+    }
+    public var asEnum: EnumDecl? {
+        self as? EnumDecl
+    }
+    public var asFunc: FuncDecl? {
+        self as? FuncDecl
+    }
+    public var asGenericParam: GenericParamDecl? {
+        self as? GenericParamDecl
+    }
+    public var asGenericType: (any GenericTypeDecl)? {
+        self as? any GenericTypeDecl
+    }
+    public var asImport: ImportDecl? {
+        self as? ImportDecl
+    }
+    public var asInit: InitDecl? {
+        self as? InitDecl
+    }
+    public var asModule: Module? {
+        self as? Module
+    }
+    public var asNominalType: (any NominalTypeDecl)? {
+        self as? any NominalTypeDecl
+    }
+    public var asCaseParam: CaseParamDecl? {
+        self as? CaseParamDecl
+    }
+    public var asFuncParam: FuncParamDecl? {
+        self as? FuncParamDecl
+    }
+    public var asProtocol: ProtocolDecl? {
+        self as? ProtocolDecl
+    }
+    public var asSourceFile: SourceFile? {
+        self as? SourceFile
+    }
+    public var asStruct: StructDecl? {
+        self as? StructDecl
+    }
+    public var asTypeAlias: TypeAliasDecl? {
+        self as? TypeAliasDecl
+    }
+    public var asType: (any TypeDecl)? {
+        self as? any TypeDecl
+    }
+    public var asValue: (any ValueDecl)? {
+        self as? any ValueDecl
+    }
+    public var asVar: VarDecl? {
+        self as? VarDecl
+    }
     // @end
 
     public var innermostContext: any DeclContext {

--- a/Sources/SwiftTypeReader/Decl/DeclContext.swift
+++ b/Sources/SwiftTypeReader/Decl/DeclContext.swift
@@ -4,19 +4,45 @@ public protocol DeclContext: AnyObject & HashableFromIdentity & _DeclParentConte
 
 extension DeclContext {
     // @codegen(as) MARK: - cast
-    public var asClass: ClassDecl? { self as? ClassDecl }
-    public var asEnumCaseElement: EnumCaseElementDecl? { self as? EnumCaseElementDecl }
-    public var asEnum: EnumDecl? { self as? EnumDecl }
-    public var asFunc: FuncDecl? { self as? FuncDecl }
-    public var asGenericContext: (any GenericContext)? { self as? any GenericContext }
-    public var asGenericType: (any GenericTypeDecl)? { self as? any GenericTypeDecl }
-    public var asInit: InitDecl? { self as? InitDecl }
-    public var asModule: Module? { self as? Module }
-    public var asNominalType: (any NominalTypeDecl)? { self as? any NominalTypeDecl }
-    public var asProtocol: ProtocolDecl? { self as? ProtocolDecl }
-    public var asSourceFile: SourceFile? { self as? SourceFile }
-    public var asStruct: StructDecl? { self as? StructDecl }
-    public var asTypeAlias: TypeAliasDecl? { self as? TypeAliasDecl }
+    public var asClass: ClassDecl? {
+        self as? ClassDecl
+    }
+    public var asEnumCaseElement: EnumCaseElementDecl? {
+        self as? EnumCaseElementDecl
+    }
+    public var asEnum: EnumDecl? {
+        self as? EnumDecl
+    }
+    public var asFunc: FuncDecl? {
+        self as? FuncDecl
+    }
+    public var asGenericContext: (any GenericContext)? {
+        self as? any GenericContext
+    }
+    public var asGenericType: (any GenericTypeDecl)? {
+        self as? any GenericTypeDecl
+    }
+    public var asInit: InitDecl? {
+        self as? InitDecl
+    }
+    public var asModule: Module? {
+        self as? Module
+    }
+    public var asNominalType: (any NominalTypeDecl)? {
+        self as? any NominalTypeDecl
+    }
+    public var asProtocol: ProtocolDecl? {
+        self as? ProtocolDecl
+    }
+    public var asSourceFile: SourceFile? {
+        self as? SourceFile
+    }
+    public var asStruct: StructDecl? {
+        self as? StructDecl
+    }
+    public var asTypeAlias: TypeAliasDecl? {
+        self as? TypeAliasDecl
+    }
     // @end
 
     public func find(name: String) -> (any Decl)? {
@@ -29,7 +55,9 @@ extension DeclContext {
                 name: name,
                 options: LookupOptions(value: false, type: true)
             )
-        else { return nil }
+        else {
+            return nil
+        }
         return (decl as! any TypeDecl)
     }
 

--- a/Sources/SwiftTypeReader/Type/SType.swift
+++ b/Sources/SwiftTypeReader/Type/SType.swift
@@ -9,18 +9,42 @@ public protocol SType: Hashable & CustomStringConvertible {
 
 extension SType {
     // @codegen(as) MARK: - cast
-    public var asClass: ClassType? { self as? ClassType }
-    public var asDependentMember: DependentMemberType? { self as? DependentMemberType }
-    public var asEnum: EnumType? { self as? EnumType }
-    public var asError: ErrorType? { self as? ErrorType }
-    public var asFunction: FunctionType? { self as? FunctionType }
-    public var asGenericParam: GenericParamType? { self as? GenericParamType }
-    public var asMetatype: MetatypeType? { self as? MetatypeType }
-    public var asModule: ModuleType? { self as? ModuleType }
-    public var asNominal: (any NominalType)? { self as? any NominalType }
-    public var asProtocol: ProtocolType? { self as? ProtocolType }
-    public var asStruct: StructType? { self as? StructType }
-    public var asTypeAlias: TypeAliasType? { self as? TypeAliasType }
+    public var asClass: ClassType? {
+        self as? ClassType
+    }
+    public var asDependentMember: DependentMemberType? {
+        self as? DependentMemberType
+    }
+    public var asEnum: EnumType? {
+        self as? EnumType
+    }
+    public var asError: ErrorType? {
+        self as? ErrorType
+    }
+    public var asFunction: FunctionType? {
+        self as? FunctionType
+    }
+    public var asGenericParam: GenericParamType? {
+        self as? GenericParamType
+    }
+    public var asMetatype: MetatypeType? {
+        self as? MetatypeType
+    }
+    public var asModule: ModuleType? {
+        self as? ModuleType
+    }
+    public var asNominal: (any NominalType)? {
+        self as? any NominalType
+    }
+    public var asProtocol: ProtocolType? {
+        self as? ProtocolType
+    }
+    public var asStruct: StructType? {
+        self as? StructType
+    }
+    public var asTypeAlias: TypeAliasType? {
+        self as? TypeAliasType
+    }
     // @end
 
     public var description: String {
@@ -47,12 +71,18 @@ extension SType {
 
     public var typeDecl: (any TypeDecl)? {
         switch self {
-        case let type as ModuleType: return type.decl
-        case let type as any NominalType: return type.nominalTypeDecl
-        case let type as TypeAliasType: return type.decl
-        case let type as GenericParamType: return type.decl
-        case let type as DependentMemberType: return type.decl
-        default: return nil
+        case let type as ModuleType:
+            return type.decl
+        case let type as any NominalType:
+            return type.nominalTypeDecl
+        case let type as TypeAliasType:
+            return type.decl
+        case let type as GenericParamType:
+            return type.decl
+        case let type as DependentMemberType:
+            return type.decl
+        default:
+            return nil
         }
     }
 }

--- a/Sources/SwiftTypeReader/TypeRepr/TypeRepr.swift
+++ b/Sources/SwiftTypeReader/TypeRepr/TypeRepr.swift
@@ -3,12 +3,24 @@ public protocol TypeRepr: Hashable & CustomStringConvertible {
 
 extension TypeRepr {
     // @codegen(as) MARK: - cast
-    public var asError: ErrorTypeRepr? { self as? ErrorTypeRepr }
-    public var asFunction: FunctionTypeRepr? { self as? FunctionTypeRepr }
-    public var asIdent: IdentTypeRepr? { self as? IdentTypeRepr }
-    public var asMetatype: MetatypeTypeRepr? { self as? MetatypeTypeRepr }
-    public var asTuple: TupleTypeRepr? { self as? TupleTypeRepr }
-    public var asComposition: CompositionTypeRepr? { self as? CompositionTypeRepr }
+    public var asError: ErrorTypeRepr? {
+        self as? ErrorTypeRepr
+    }
+    public var asFunction: FunctionTypeRepr? {
+        self as? FunctionTypeRepr
+    }
+    public var asIdent: IdentTypeRepr? {
+        self as? IdentTypeRepr
+    }
+    public var asMetatype: MetatypeTypeRepr? {
+        self as? MetatypeTypeRepr
+    }
+    public var asTuple: TupleTypeRepr? {
+        self as? TupleTypeRepr
+    }
+    public var asComposition: CompositionTypeRepr? {
+        self as? CompositionTypeRepr
+    }
     // @end
 
     public func resolve(from context: any DeclContext) -> any SType {

--- a/Sources/SwiftTypeReader/TypeTransform/TypeTransformer.swift
+++ b/Sources/SwiftTypeReader/TypeTransform/TypeTransformer.swift
@@ -4,16 +4,22 @@ open class TypeTransformer {
     }
 
     private func walk(_ type: (any SType)?) -> (any SType)? {
-        guard let type else { return nil }
+        guard let type else {
+            return nil
+        }
         return walk(type)
     }
 
     private func walk(_ types: [any SType]) -> [any SType] {
-        return types.map { walk($0) }
+        return types.map {
+            walk($0)
+        }
     }
 
     private func walk(_ params: [FunctionType.Param]) -> [FunctionType.Param] {
-        params.map { walk($0) }
+        params.map {
+            walk($0)
+        }
     }
 
     private func walk(_ param: FunctionType.Param) -> FunctionType.Param {
@@ -25,39 +31,75 @@ open class TypeTransformer {
     // @codegen(dispatch)
     private func dispatch(type: any SType) -> any SType {
         switch type {
-        case let t as ClassType: return visitImpl(class: t)
-        case let t as DependentMemberType: return visitImpl(dependentMember: t)
-        case let t as EnumType: return visitImpl(enum: t)
-        case let t as ErrorType: return visitImpl(error: t)
-        case let t as FunctionType: return visitImpl(function: t)
-        case let t as GenericParamType: return visitImpl(genericParam: t)
-        case let t as MetatypeType: return visitImpl(metatype: t)
-        case let t as ModuleType: return visitImpl(module: t)
-        case let t as ProtocolType: return visitImpl(protocol: t)
-        case let t as StructType: return visitImpl(struct: t)
-        case let t as TypeAliasType: return visitImpl(typeAlias: t)
-        default: return type
+        case let t as ClassType:
+            return visitImpl(class: t)
+        case let t as DependentMemberType:
+            return visitImpl(dependentMember: t)
+        case let t as EnumType:
+            return visitImpl(enum: t)
+        case let t as ErrorType:
+            return visitImpl(error: t)
+        case let t as FunctionType:
+            return visitImpl(function: t)
+        case let t as GenericParamType:
+            return visitImpl(genericParam: t)
+        case let t as MetatypeType:
+            return visitImpl(metatype: t)
+        case let t as ModuleType:
+            return visitImpl(module: t)
+        case let t as ProtocolType:
+            return visitImpl(protocol: t)
+        case let t as StructType:
+            return visitImpl(struct: t)
+        case let t as TypeAliasType:
+            return visitImpl(typeAlias: t)
+        default:
+            return type
         }
     }
     // @end
 
     // @codegen(visit)
-    open func visit(class type: ClassType) -> (any SType)? { nil }
-    open func visit(dependentMember type: DependentMemberType) -> (any SType)? { nil }
-    open func visit(enum type: EnumType) -> (any SType)? { nil }
-    open func visit(error type: ErrorType) -> (any SType)? { nil }
-    open func visit(function type: FunctionType) -> (any SType)? { nil }
-    open func visit(genericParam type: GenericParamType) -> (any SType)? { nil }
-    open func visit(metatype type: MetatypeType) -> (any SType)? { nil }
-    open func visit(module type: ModuleType) -> (any SType)? { nil }
-    open func visit(protocol type: ProtocolType) -> (any SType)? { nil }
-    open func visit(struct type: StructType) -> (any SType)? { nil }
-    open func visit(typeAlias type: TypeAliasType) -> (any SType)? { nil }
+    open func visit(class type: ClassType) -> (any SType)? {
+        nil
+    }
+    open func visit(dependentMember type: DependentMemberType) -> (any SType)? {
+        nil
+    }
+    open func visit(enum type: EnumType) -> (any SType)? {
+        nil
+    }
+    open func visit(error type: ErrorType) -> (any SType)? {
+        nil
+    }
+    open func visit(function type: FunctionType) -> (any SType)? {
+        nil
+    }
+    open func visit(genericParam type: GenericParamType) -> (any SType)? {
+        nil
+    }
+    open func visit(metatype type: MetatypeType) -> (any SType)? {
+        nil
+    }
+    open func visit(module type: ModuleType) -> (any SType)? {
+        nil
+    }
+    open func visit(protocol type: ProtocolType) -> (any SType)? {
+        nil
+    }
+    open func visit(struct type: StructType) -> (any SType)? {
+        nil
+    }
+    open func visit(typeAlias type: TypeAliasType) -> (any SType)? {
+        nil
+    }
     // @end
 
     // @codegen(visitImpl)
     private func visitImpl(class type: ClassType) -> any SType {
-        if let t = visit(class: type) { return t }
+        if let t = visit(class: type) {
+            return t
+        }
         var type = type
         type.parent = walk(type.parent)
         type.genericArgs = walk(type.genericArgs)
@@ -65,14 +107,18 @@ open class TypeTransformer {
     }
 
     private func visitImpl(dependentMember type: DependentMemberType) -> any SType {
-        if let t = visit(dependentMember: type) { return t }
+        if let t = visit(dependentMember: type) {
+            return t
+        }
         var type = type
         type.base = walk(type.base)
         return type
     }
 
     private func visitImpl(enum type: EnumType) -> any SType {
-        if let t = visit(enum: type) { return t }
+        if let t = visit(enum: type) {
+            return t
+        }
         var type = type
         type.parent = walk(type.parent)
         type.genericArgs = walk(type.genericArgs)
@@ -80,12 +126,16 @@ open class TypeTransformer {
     }
 
     private func visitImpl(error type: ErrorType) -> any SType {
-        if let t = visit(error: type) { return t }
+        if let t = visit(error: type) {
+            return t
+        }
         return type
     }
 
     private func visitImpl(function type: FunctionType) -> any SType {
-        if let t = visit(function: type) { return t }
+        if let t = visit(function: type) {
+            return t
+        }
         var type = type
         type.params = walk(type.params)
         type.result = walk(type.result)
@@ -93,29 +143,39 @@ open class TypeTransformer {
     }
 
     private func visitImpl(genericParam type: GenericParamType) -> any SType {
-        if let t = visit(genericParam: type) { return t }
+        if let t = visit(genericParam: type) {
+            return t
+        }
         return type
     }
 
     private func visitImpl(metatype type: MetatypeType) -> any SType {
-        if let t = visit(metatype: type) { return t }
+        if let t = visit(metatype: type) {
+            return t
+        }
         var type = type
         type.instance = walk(type.instance)
         return type
     }
 
     private func visitImpl(module type: ModuleType) -> any SType {
-        if let t = visit(module: type) { return t }
+        if let t = visit(module: type) {
+            return t
+        }
         return type
     }
 
     private func visitImpl(protocol type: ProtocolType) -> any SType {
-        if let t = visit(protocol: type) { return t }
+        if let t = visit(protocol: type) {
+            return t
+        }
         return type
     }
 
     private func visitImpl(struct type: StructType) -> any SType {
-        if let t = visit(struct: type) { return t }
+        if let t = visit(struct: type) {
+            return t
+        }
         var type = type
         type.parent = walk(type.parent)
         type.genericArgs = walk(type.genericArgs)
@@ -123,7 +183,9 @@ open class TypeTransformer {
     }
 
     private func visitImpl(typeAlias type: TypeAliasType) -> any SType {
-        if let t = visit(typeAlias: type) { return t }
+        if let t = visit(typeAlias: type) {
+            return t
+        }
         var type = type
         type.parent = walk(type.parent)
         type.genericArgs = walk(type.genericArgs)


### PR DESCRIPTION
CodegenKit の SwiftSyntax等の 対応の遅れを追従したので依存設定を復活させます。

CodegenKit 側では複数バージョンの SwiftSyntax をCIでテストできるようにするなどして、
今後の運用がしやすいように改善しました。

また、 codegenkitはswift-formatに依存していることで、
swift-formatの追従遅れに律速されるのが運用を困難にしていたので、
swift-formatへの依存を外しました。

- #60 

で、traitを使ってスイッチする方法を提案してもらいましたが、
残念ながら、
パッケージ依存自体を消したり、
ターゲットの存在を消すことは trait の機能ではできないようでした。

一方で、
CodegenKit は SwiftTypeReader の executable, plugin にしか関連がなく、
product library からは依存されていないため、
SwiftTypeReaderを利用するプロダクト側においては、
CodegenKit はビルド解決から外されており、無害なようでした。

また SwiftTypeReader のアップデートにおいて障害となるようであれば、
その時はまた一時的にCodegenKitの依存を外せば良さそうです。