### PR TITLE
CI で複数の Swift Syntax バージョンを検証する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,32 @@
 name: test
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
+    name: "test (swift-syntax: ${{ matrix.swift-syntax-version }})"
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        swift-syntax-version:
+          - "602.0.0..<603.0.0"
+          - "603.0.0..<604.0.0"
+
     steps:
       - uses: actions/checkout@v4
-      - run: swift test
+
+      - uses: vapor/swiftly-action@v0.2
+        with:
+          toolchain: "6.3"
+
+      - name: Test
+        run: swift test
+        env:
+          SWIFTTYPEREADER_SWIFTSYNTAX_VERSION: ${{ matrix.swift-syntax-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 xcuserdata/
 DerivedData/
 /.swiftpm
+.vscode

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "22fd52a2c30e65376b609473a09ab67e89ebf4e2a0116a6f2ba397eadafa5828",
+  "originHash" : "148c22755b7ede543fa0021b6e8eabcc1b774b174df39e05d70511972bc864f1",
   "pins" : [
     {
       "identity" : "codegenkit",

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "148c22755b7ede543fa0021b6e8eabcc1b774b174df39e05d70511972bc864f1",
+  "originHash" : "0a72dabba2ad1fe7d6d89dcf9533104ebd7a8811970de01f3dfaf9e8aac0de26",
   "pins" : [
     {
       "identity" : "codegenkit",

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 
 import PackageDescription
 
-let defaultSwiftSyntaxVersionRange: Range<Version> = "603.0.0"..<"999.0.0"
+let defaultSwiftSyntaxVersionRange: Range<Version> = "602.0.0"..<"999.0.0"
 
 func swiftSyntaxVersionRange() -> Range<Version> {
     let key = "SWIFTTYPEREADER_SWIFTSYNTAX_VERSION"

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,27 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.0
 
 import PackageDescription
+
+let defaultSwiftSyntaxVersionRange: Range<Version> = "603.0.0"..<"999.0.0"
+
+func swiftSyntaxVersionRange() -> Range<Version> {
+    let key = "SWIFTTYPEREADER_SWIFTSYNTAX_VERSION"
+
+    guard let versionString = Context.environment[key] else {
+        return defaultSwiftSyntaxVersionRange
+    }
+
+    let rangeParts = versionString.split(separator: "..<", maxSplits: 1).map(String.init)
+    guard
+        rangeParts.count == 2,
+        let lowerBound = Version(rangeParts[0]),
+        let upperBound = Version(rangeParts[1])
+    else {
+        fatalError("Invalid \(key): \(versionString)")
+    }
+
+    return lowerBound..<upperBound
+}
 
 let package = Package(
     name: "SwiftTypeReader",
@@ -12,7 +33,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", "603.0.1"..<"999.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", swiftSyntaxVersionRange()),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.3"),
         .package(url: "https://github.com/omochi/CodegenKit.git", from: "2.1.1"),
     ],

--- a/Sources/SwiftTypeReader/Reader/SwiftIfConfigCompatibility.swift
+++ b/Sources/SwiftTypeReader/Reader/SwiftIfConfigCompatibility.swift
@@ -1,0 +1,98 @@
+import SwiftIfConfig
+import SwiftSyntax
+
+#if canImport(SwiftSyntax603)
+public typealias StaticBuildConfiguration = SwiftIfConfig.StaticBuildConfiguration
+#else
+public struct StaticBuildConfiguration: BuildConfiguration {
+    public var customConditions: Set<String>
+    public var features: Set<String>
+    public var attributes: Set<String>
+    public var importableModules: Set<String>
+    public var targetOSs: Set<String>
+    public var targetArchitectures: Set<String>
+    public var targetEnvironments: Set<String>
+    public var targetRuntimes: Set<String>
+    public var targetPointerAuthentications: Set<String>
+    public var targetPointerBitWidth: Int
+    public var targetAtomicBitWidths: [Int]
+    public var endianness: Endianness
+    public var languageVersion: VersionTuple
+    public var compilerVersion: VersionTuple
+
+    public init(
+        customConditions: Set<String> = [],
+        features: Set<String> = [],
+        attributes: Set<String> = [],
+        importableModules: Set<String> = [],
+        targetOSs: Set<String> = [],
+        targetArchitectures: Set<String> = [],
+        targetEnvironments: Set<String> = [],
+        targetRuntimes: Set<String> = [],
+        targetPointerAuthentications: Set<String> = [],
+        targetPointerBitWidth: Int = 64,
+        targetAtomicBitWidths: [Int] = [8, 16, 32, 64],
+        endianness: Endianness = .little,
+        languageVersion: VersionTuple,
+        compilerVersion: VersionTuple
+    ) {
+        self.customConditions = customConditions
+        self.features = features
+        self.attributes = attributes
+        self.importableModules = importableModules
+        self.targetOSs = targetOSs
+        self.targetArchitectures = targetArchitectures
+        self.targetEnvironments = targetEnvironments
+        self.targetRuntimes = targetRuntimes
+        self.targetPointerAuthentications = targetPointerAuthentications
+        self.targetPointerBitWidth = targetPointerBitWidth
+        self.targetAtomicBitWidths = targetAtomicBitWidths
+        self.endianness = endianness
+        self.languageVersion = languageVersion
+        self.compilerVersion = compilerVersion
+    }
+
+    public func isCustomConditionSet(name: String) throws -> Bool {
+        customConditions.contains(name)
+    }
+
+    public func hasFeature(name: String) throws -> Bool {
+        features.contains(name)
+    }
+
+    public func hasAttribute(name: String) throws -> Bool {
+        attributes.contains(name)
+    }
+
+    public func canImport(importPath: [(TokenSyntax, String)], version: CanImportVersion) throws -> Bool {
+        guard let moduleName = importPath.first?.1 else {
+            return false
+        }
+        return importableModules.contains(moduleName)
+    }
+
+    public func isActiveTargetOS(name: String) throws -> Bool {
+        targetOSs.contains(name)
+    }
+
+    public func isActiveTargetArchitecture(name: String) throws -> Bool {
+        targetArchitectures.contains(name)
+    }
+
+    public func isActiveTargetEnvironment(name: String) throws -> Bool {
+        targetEnvironments.contains(name)
+    }
+
+    public func isActiveTargetRuntime(name: String) throws -> Bool {
+        targetRuntimes.contains(name)
+    }
+
+    public func isActiveTargetPointerAuthentication(name: String) throws -> Bool {
+        targetPointerAuthentications.contains(name)
+    }
+
+    public func isActiveTargetObjectFormat(name: String) throws -> Bool {
+        false
+    }
+}
+#endif


### PR DESCRIPTION
サポート下限を602に緩和して、
Package.swift に穴を開けて、
CI を 602系と 603系の両方で回すようにする。

602 については SwiftIfConfig で使う StaticBuildConfiguration がないという点で互換性がないが、
API になっている `BuildConfiguration` プロトコルは 602 でも存在しているので、
`StaticBuildConfiguration` を自前でポリフィルすることで対応する。

現在 602 をサポートしたい理由があるわけではないが、
プロジェクトとして２バージョン同時に保守できる仕組みがないと、
新しい SwiftSyntax が出た時に関連パッケージを段階的に移行するのが難しくなるので、
将来603, 604 のクロスサポートがしやすいように、
602, 603 で仕組みを作っておく。